### PR TITLE
Minor changes so "setup.py" is useful

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,14 @@ from setuptools import setup, find_packages
 setup(
     name='sdb',
     version="0.1.0",
-    packages=find_packages(exclude=['crash-python-contrib']),
+
+    packages=[
+        "sdb",
+        "sdb.command",
+        "sdb.internal",
+        "sdb.repl",
+    ],
+
     entry_points={
         'console_scripts': ['sdb=sdb.internal.cli:main'],
     },


### PR DESCRIPTION
Currently, when running "python setup.py install" it won't install
anything useful. For example, it doesn't install any "sdb" python
pacakges, and as a result the installed "sdb" script doesn't work.

The problem is the use of "find_packages" doesn't appear to work, given
the directory structure of this repository (it emits an empty list). For
now, we fix this by explicitly listing all the "sdb" packages.

Additionally, in order for the "sdb" script to work, we also need to
install an "sdb" package, so this change adds an empty "__init__.py"
file, so that we can create and install an "sdb" package (in addition to
the other "sdb.*" packages).