### PR TITLE
Merge - Bleeding Edge

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -17,7 +17,7 @@ $ python3 -m pytest
 * [Black](https://black.readthedocs.io)
 ```
 $ python3 -m pip install black
-$ black sdb
+$ python3 -m black sdb
 ```
 
 `pylint`, `isort`, and `yapf` are also used to some extend, but are not

--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -2,9 +2,11 @@
 # -*- coding: utf-8 -*-
 
 """
-XXX
+This file contains all the logic of the sdb "executable"
+like the entry point, command line interface, etc...
 """
 
+import argparse
 import sys
 
 import drgn
@@ -12,13 +14,147 @@ from sdb.command import allSDBCommands
 from sdb.repl import REPL
 
 
-def main():
+def parse_arguments() -> argparse.Namespace:
+    """
+    Sets up argument parsing and does the first pass of validation
+    of the command line input.
+    """
+    parser = argparse.ArgumentParser(
+        prog="sdb", description="The Slick/Simple Debugger"
+    )
+
+    dump_group = parser.add_argument_group("core/crash dump analysis")
+    dump_group.add_argument(
+        "object",
+        nargs="?",
+        default="",
+        help="a namelist like vmlinux or userland binary",
+    )
+    dump_group.add_argument(
+        "core", nargs="?", default="", help="the core/crash dump to be debugged"
+    )
+
+    live_group = parser.add_argument_group(
+        "live system analysis"
+    ).add_mutually_exclusive_group()
+    live_group.add_argument(
+        "-k", "--kernel", action="store_true", help="debug the running kernel (default)"
+    )
+    live_group.add_argument(
+        "-p",
+        "--pid",
+        metavar="PID",
+        type=int,
+        help="debug the running process of the specified PID",
+    )
+
+    dis_group = parser.add_argument_group("debug info and symbols")
+    dis_group.add_argument(
+        "-s",
+        "--symbol-search",
+        metavar="PATH",
+        type=str,
+        action="append",
+        help="load debug info and symbols from the given directory or file;"
+        + " this may option may be given more than once",
+    )
+    dis_group.add_argument(
+        "-A",
+        "--no-default-symbols",
+        dest="default_symbols",
+        action="store_false",
+        help="don't load any debugging symbols that were not explicitly added with -d",
+    )
+
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="don't print non-fatal warnings"
+    )
+    args = parser.parse_args()
+
+    #
+    # If an 'object' (and maybe 'core') parameter has been specified
+    # we are analyzing a core dump or a crash dump. With that in mind
+    # it is harder to user argparse to make the above two mutually
+    # exclusive with '-k' or '-p PID' which are for analyzing live
+    # targets. As a result we enforce this mutual exclusions on our
+    # own below. Unfortunately this is still not close to ideal as
+    # the help message will show something like this:
+    # ```
+    # usage: sdb [-h] [-k | -p PID] [-d PATH] ... [object] [core]
+    # ```
+    # instead of:
+    # ```
+    # usage: sdb [-h] [-k | -p PID | object core] [-d PATH] ...
+    # ```
+    #
+    if args.object and args.kernel:
+        parser.error("cannot specify an object file while also specifying --kernel")
+    if args.object and args.pid:
+        parser.error("cannot specify an object file while also specifying --pid")
+
+    #
+    # We currently cannot handle object files without cores.
+    #
+    if args.object and not args.core:
+        parser.error("raw object file target is not supported yet")
+    return args
+
+
+def setup_target(args: argparse.Namespace) -> drgn.Program:
+    """
+    Based on the validated input from the command line, setup the
+    drgn.Program for our target and its metadata.
+    """
     prog = drgn.Program()
-    prog.set_kernel()
-    try:
-        prog.load_default_debug_info()
-    except drgn.MissingDebugInfoError as e:
-        print(str(e), file=sys.stderr)
+    if args.core:
+        prog.set_core_dump(args.core)
+
+        #
+        # This is currently a short-coming of drgn. Whenever we
+        # open a crash/core dump we need to specify the vmlinux
+        # or userland binary using the non-default debug info
+        # load API.
+        #
+        prog.load_debug_info(args.object)
+    elif args.pid:
+        prog.set_pid(args.pid)
+    else:
+        prog.set_kernel()
+
+    if args.default_symbols:
+        try:
+            prog.load_default_debug_info()
+        except drgn.MissingDebugInfoError as debug_info_err:
+            #
+            # If we encounter such an error it means that we can't
+            # find the debug info for one or more kernel modules.
+            # That's fine because the user may not need those, so
+            # print a warning and proceed.
+            #
+            if not args.quiet:
+                print("sdb: " + str(debug_info_err), file=sys.stderr)
+
+    if args.symbol_search:
+        try:
+            prog.load_debug_info(args.symbol_search)
+        except (
+            drgn.FileFormatError,
+            drgn.MissingDebugInfoError,
+            OSError,
+        ) as debug_info_err:
+            #
+            # See similar comment above
+            #
+            if not args.quiet:
+                print("sdb: " + str(debug_info_err), file=sys.stderr)
+
+    return prog
+
+
+def main() -> None:
+    """ The entry point of the sdb "executable" """
+    args = parse_arguments()
+    prog = setup_target(args)
     repl = REPL(prog, allSDBCommands)
     repl.run()
 

--- a/tests/command/test_base.py
+++ b/tests/command/test_base.py
@@ -4,7 +4,9 @@ import sdb.command as sdbc
 
 from typing import Iterable
 
-tprog = drgn.Program(drgn.Architecture.IS_LITTLE_ENDIAN)
+tplatform = drgn.Platform(drgn.Architecture.UNKNOWN,
+                          drgn.PlatformFlags.IS_LITTLE_ENDIAN)
+tprog = drgn.Program(tplatform)
 
 
 def get_cmd(cmd: str, args: str = '') -> sdbc.SDBCommand:


### PR DESCRIPTION
# Crash Dump Support

The libkdumpfile PR was merged into `drgn`.

I adjusted `sdb` to take crash/core dumps as arguments:
```
$ sudo sdb dump/vmlinux-4.15.0-47-generic dump/dump.201904221843 -s dump
> addr spa_namespace_avl
*(avl_tree_t *)0xffffffffc09c0ce0 = {
    .avl_root = (struct avl_node *)0xffff8c4fe7634108,
    .avl_compar = (int (*)(const void *, const void *))0xffffffffc0788630,
    .avl_offset = (size_t)264,
    .avl_numnodes = (ulong_t)2,
    .avl_size = (size_t)8736,
}
> addr spa_namespace_avl | walk avl
(void *)0xffff8c4fe7634000
(void *)0xffff8c4fc0680000
>
```
The current CLI interface is something like that:
```
sdb # no options does live-kernel debugging
sdb <vmlinux> <dump> -s <directory with kernel modules>
```

## Side changes
- Fix breakage in tests after latest `drgn` updates
- nits in docs
- CLI option for attaching to live processes (WIP: still need to do work for getting userland debug links in `drgn` for that to work completely)