### PR TITLE
Rename "sdb.repl" to "sdb.internal.repl"

### DIFF
--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -12,7 +12,7 @@ import sys
 
 import drgn
 from sdb.command import allSDBCommands
-from sdb.repl import REPL
+from sdb.internal.repl import REPL
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-"""This module exists solely for the REPL class"""
 import readline
 
 from sdb.command import SDBCommand

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
         "sdb",
         "sdb.command",
         "sdb.internal",
-        "sdb.repl",
     ],
 
     entry_points={


### PR DESCRIPTION
This renames the "sdb.repl" modules to be within "sdb.internal" since
the REPL used by sdb is meant to only be used internally by "sdb".