### PR TITLE
Catch permission error opening "/proc/kcore"

### DIFF
--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -180,7 +180,13 @@ def setup_target(args: argparse.Namespace) -> drgn.Program:
 def main() -> None:
     """ The entry point of the sdb "executable" """
     args = parse_arguments()
-    prog = setup_target(args)
+
+    try:
+        prog = setup_target(args)
+    except PermissionError as e:
+        print("sdb: " + str(e))
+        return
+
     repl = REPL(prog, allSDBCommands)
     repl.run()
 


### PR DESCRIPTION
When running "sdb" as a non-root user, we may fail to open "/proc/kcore"
due to lacking permissions. This change replaces the exception that
would be show to the user, with a more appropriate error message.

For example, before this change:

    $ sdb
    Traceback (most recent call last):
      File "/usr/local/bin/sdb", line 11, in <module>
        load_entry_point('sdb==0.1.0', 'console_scripts', 'sdb')()
      File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 183, in main
      File "/usr/local/lib/python3.6/dist-packages/sdb-0.1.0-py3.6.egg/sdb/internal/cli.py", line 144, in setup_target
    PermissionError: [Errno 13] Permission denied: '/proc/kcore'

After this change:

    $ sdb
    sdb: [Errno 13] Permission denied: '/proc/kcore'