### PR TITLE
Enable "sdb.invoke" to be used programmatically

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -98,7 +98,8 @@ def execute_pipeline_term(prog: drgn.Program,
     pipeline[-1].call(this_input)
 
 
-def invoke(prog: drgn.Program, line: str) -> Optional[Iterable[drgn.Object]]:
+def invoke(prog: drgn.Program, first_input: Iterable[drgn.Object],
+           line: str) -> Optional[Iterable[drgn.Object]]:
     """
     This function intends to integrate directly with the SDB REPL, such
     that the REPL will pass in the user-specified line, and this
@@ -172,9 +173,9 @@ def invoke(prog: drgn.Program, line: str) -> Optional[Iterable[drgn.Object]]:
 
     try:
         if pipeline[-1].ispipeable:
-            yield from execute_pipeline(prog, [], pipeline)
+            yield from execute_pipeline(prog, first_input, pipeline)
         else:
-            execute_pipeline_term(prog, [], pipeline)
+            execute_pipeline_term(prog, first_input, pipeline)
 
         if shell_cmd is not None:
             shell_proc.stdin.flush()

--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -98,7 +98,7 @@ def execute_pipeline_term(prog: drgn.Program,
     pipeline[-1].call(this_input)
 
 
-def invoke(prog: drgn.Program, line: str) -> None:
+def invoke(prog: drgn.Program, line: str) -> Optional[Iterable[drgn.Object]]:
     """
     This function intends to integrate directly with the SDB REPL, such
     that the REPL will pass in the user-specified line, and this
@@ -172,8 +172,7 @@ def invoke(prog: drgn.Program, line: str) -> None:
 
     try:
         if pipeline[-1].ispipeable:
-            for obj in execute_pipeline(prog, [], pipeline):
-                print(obj)
+            yield from execute_pipeline(prog, [], pipeline)
         else:
             execute_pipeline_term(prog, [], pipeline)
 

--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -72,8 +72,8 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
                 Vdev(self.prog, self.arg_string).pretty_print(vdevs, 5)
 
     def no_input(self):
-        spas = sdb.invoke(self.prog,
-                          'addr spa_namespace_avl | avl | cast spa_t *')
+        spas = sdb.invoke(self.prog, [self.prog["spa_namespace_avl"]],
+                          'avl | cast spa_t *')
         for spa in spas:
             if (self.args.poolnames and
                     spa.spa_name.string_() not in self.args.poolnames):

--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -20,8 +20,6 @@ import argparse
 
 import drgn
 import sdb
-from sdb.commands.cast import Cast
-from sdb.commands.zfs.avl import Avl
 from sdb.commands.zfs.vdev import Vdev
 
 
@@ -74,11 +72,8 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
                 Vdev(self.prog, self.arg_string).pretty_print(vdevs, 5)
 
     def no_input(self):
-        spas = sdb.execute_pipeline(
-            self.prog,
-            [self.prog["spa_namespace_avl"].address_of_()],
-            [Avl(self.prog), Cast(self.prog, "spa_t *")],
-        )
+        spas = sdb.invoke(self.prog,
+                          'addr spa_namespace_avl | avl | cast spa_t *')
         for spa in spas:
             if (self.args.poolnames and
                     spa.spa_name.string_() not in self.args.poolnames):

--- a/sdb/commands/zfs/zfs_dbgmsg.py
+++ b/sdb/commands/zfs/zfs_dbgmsg.py
@@ -22,8 +22,6 @@ from typing import Iterable
 
 import drgn
 import sdb
-from sdb.commands.cast import Cast
-from sdb.commands.zfs.list import List
 
 
 class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
@@ -66,12 +64,8 @@ class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
             ZfsDbgmsg.print_msg(obj, self.verbosity >= 1, self.verbosity >= 2)
 
     def no_input(self) -> Iterable[drgn.Object]:
-        proc_list = self.prog["zfs_dbgmsgs"].pl_list
-        list_addr = proc_list.address_of_()
-
-        # pylint: disable=C0330
-        for obj in sdb.execute_pipeline(
-                self.prog, [list_addr],
-            [List(self.prog),
-             Cast(self.prog, "zfs_dbgmsg_t *")]):
+        for obj in sdb.invoke(
+                self.prog,
+                'addr zfs_dbgmsgs | member pl_list | addr | list | cast zfs_dbgmsg_t *'
+        ):
             yield obj

--- a/sdb/commands/zfs/zfs_dbgmsg.py
+++ b/sdb/commands/zfs/zfs_dbgmsg.py
@@ -64,8 +64,6 @@ class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
             ZfsDbgmsg.print_msg(obj, self.verbosity >= 1, self.verbosity >= 2)
 
     def no_input(self) -> Iterable[drgn.Object]:
-        for obj in sdb.invoke(
-                self.prog,
-                'addr zfs_dbgmsgs | member pl_list | addr | list | cast zfs_dbgmsg_t *'
-        ):
+        for obj in sdb.invoke(self.prog, [self.prog["zfs_dbgmsgs"].pl_list],
+                              'list | cast zfs_dbgmsg_t *'):
             yield obj

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -66,7 +66,7 @@ class REPL:
                 if not line:
                     continue
 
-                objs = sdb.invoke(self.target, line)
+                objs = sdb.invoke(self.target, [], line)
                 if not objs:
                     continue
 

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -65,7 +65,14 @@ class REPL:
                 line = input(self.prompt).strip()
                 if not line:
                     continue
-                sdb.invoke(self.target, line)
+
+                objs = sdb.invoke(self.target, line)
+                if not objs:
+                    continue
+
+                for obj in objs:
+                    print(obj)
+
             except (EOFError, KeyboardInterrupt):
                 print(self.closing)
                 break


### PR DESCRIPTION
This change slightly modifies the `invoke` method, such that it optionally returns a list of `drgn.Object` objects. This slight modification drastically increases it's utility, since we can then use this function programmatically to implement other SDB commands. For example, this change also modifies the implementation of the `spa` and `zfs_dbgmsg` commands to take advantage of this new functionality.

A couple things to note:

1. If we want to adopt this new approach, for building new SDB commands by way of `sdb.invoke`, we'll likely want to modify certain aspects of our infrastructure classes. For example, currently if a pipeline ends in a `PrettyPrinter` command, that pipeline won't return any objects. Instead, it will return `None`, and print out the objects instead.

   To fully embrace this new model, I think we'll want to ensure that even if a pipeline ends with a `PrettyPrinter`, it'll still return the objects instead of printing them. Thus, this may mean we have to explicitly append `| pp` to all pipelines executed via the REPL, in order them to be pretty printed.

2. ~~We likely need another interface to `invoke`, to allow us to pass in `drgn.Objects` as the first input to the pipeline. Currently, the `sdb.execute_pipeline` function has this functionality, but `sdb.invoke` does not. Thus, we'll want/need to extend `sdb.invoke` to allow us to add objects to the front of the pipeline.~~ I've since implemented this part.

3. If this new approach works out, we might also want to completely remove the `sdb.execute_pipeline` and `sdb.execute_pipeline_term` functions (i.e. keep them only as an internal implementation detail of `invoke`, and stop using it externally in the command classes), since the functionality of both will be able to be accomplished via `sdb.invoke`.