### PR TITLE
Consistently use argparse for argument parsing

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -149,12 +149,16 @@ def invoke(prog: drgn.Program, first_input: Iterable[drgn.Object],
     for stage in pipe_stages:
         (name, _, args) = stage.strip().partition(" ")
         try:
-            if args:
-                pipeline.append(all_commands[name](prog, args))
-            else:
-                pipeline.append(all_commands[name](prog))
+            pipeline.append(all_commands[name](prog, args, name))
         except KeyError:
             print("sdb: cannot recognize command: {}".format(name))
+            return
+        except SystemExit:
+            # The passed in arguments to each command will be parsed in
+            # the command object's constructor. We use "argparse" to do
+            # the argument parsing, and when that detects an error, it
+            # will throw this exception. Rather than exiting the entire
+            # SDB session, we only abort this specific pipeline.
             return
 
     pipeline[-1].islast = True

--- a/sdb/command.py
+++ b/sdb/command.py
@@ -15,6 +15,7 @@
 #
 """This module contains the "sdb.Command" class."""
 
+import argparse
 import inspect
 from typing import Iterable, List, Optional
 
@@ -36,15 +37,20 @@ class Command:
     names: List[str] = []
     input_type: Optional[str] = None
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
         self.prog = prog
-        self.args = args
+        self.name = name
         self.islast = False
         self.ispipeable = False
 
         if inspect.signature(
                 self.call).return_annotation == Iterable[drgn.Object]:
             self.ispipeable = True
+
+        parser = argparse.ArgumentParser(prog=name)
+        self._init_argparse(parser)
+        self.args = parser.parse_args(args.split())
 
     def __init_subclass__(cls, **kwargs):
         """
@@ -55,6 +61,9 @@ class Command:
         super().__init_subclass__(**kwargs)
         for name in cls.names:
             sdb.register_command(name, cls)
+
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        pass
 
     def call(self,
              objs: Iterable[drgn.Object]) -> Optional[Iterable[drgn.Object]]:

--- a/sdb/commands/address.py
+++ b/sdb/commands/address.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=missing-docstring
 
+import argparse
 from typing import Iterable
 
 import drgn
@@ -41,15 +42,13 @@ class Address(sdb.Command):
 
     names = ["address", "addr"]
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        self.args = args
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("symbols", nargs="*", metavar="<symbol>")
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
-        if self.args:
-            for arg in self.args.split():
-                yield resolve_for_address(self.prog, arg)
-        else:
-            for obj in objs:
-                assert obj.address_of_() is not None
-                yield obj.address_of_()
+        for obj in objs:
+            assert obj.address_of_() is not None
+            yield obj.address_of_()
+
+        for symbol in self.args.symbols:
+            yield resolve_for_address(self.prog, symbol)

--- a/sdb/commands/cast.py
+++ b/sdb/commands/cast.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=missing-docstring
 
+import argparse
 from typing import Iterable
 
 import drgn
@@ -27,9 +28,24 @@ class Cast(sdb.Command):
 
     names = ["cast"]
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        self.type = self.prog.type(args)
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
+        super().__init__(prog, args, name)
+        if not self.args.type:
+            self.parser.error("the following arguments are required: type")
+
+        self.type = self.prog.type(" ".join(self.args.type))
+
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        #
+        # We use REMAINDER here to allow the type to be specified
+        # without the user having to worry about escaping whitespace.
+        # The drawback of this is an error will not be automatically
+        # thrown if no type is provided. To workaround this, we check
+        # the parsed arguments, and explicitly throw an error if needed.
+        #
+        parser.add_argument("type", nargs=argparse.REMAINDER)
+        self.parser = parser
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for obj in objs:

--- a/sdb/commands/echo.py
+++ b/sdb/commands/echo.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=missing-docstring
 
+import argparse
 from typing import Iterable
 
 import drgn
@@ -27,12 +28,12 @@ class Echo(sdb.Command):
 
     names = ["echo", "cc"]
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        self.args = args
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("addrs", nargs="*", metavar="<address>")
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
-        for arg in self.args.split():
-            yield drgn.Object(self.prog, "void *", value=int(arg, 0))
         for obj in objs:
             yield obj
+
+        for addr in self.args.addrs:
+            yield drgn.Object(self.prog, "void *", value=int(addr, 0))

--- a/sdb/commands/help.py
+++ b/sdb/commands/help.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=missing-docstring
 
+import argparse
 from typing import Iterable
 
 import drgn
@@ -33,20 +34,16 @@ class Help(sdb.Command):
 
     names = ["help"]
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        self.args = args
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("commands", nargs="+", metavar="<command>")
 
     def call(self, objs: Iterable[drgn.Object]) -> None:
-        if not self.args:
-            print("syntax: help <command> [<command> ...]")
-            return
-        for cmd in self.args.split():
-            if cmd in sdb.all_commands:
-                print(cmd)
-                if sdb.all_commands[cmd].__doc__ is None:
+        for command in self.args.commands:
+            if command in sdb.all_commands:
+                print(command)
+                if sdb.all_commands[command].__doc__ is None:
                     print("\n    <undocumented>\n")
                     return
-                print(sdb.all_commands[cmd].__doc__)
+                print(sdb.all_commands[command].__doc__)
             else:
-                print("command " + cmd + " doesn't exist")
+                print("command " + command + " doesn't exist")

--- a/sdb/commands/linux_hlist.py
+++ b/sdb/commands/linux_hlist.py
@@ -29,21 +29,12 @@ class LinuxHList(sdb.Walker):
     names = ["linux_hlist"]
     input_type = "struct hlist_head *"
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        parser = argparse.ArgumentParser(description="walk a linux hlist")
-        parser.add_argument(
-            "offset",
-            default=0,
-            type=int,
-            nargs="?",
-            help="offset of list_head in structure",
-        )
-
-        try:
-            self.args = parser.parse_args(args.split())
-        except SystemExit:
-            pass
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("offset",
+                            default=0,
+                            type=int,
+                            nargs="?",
+                            help="offset of list_head in structure")
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         node = obj.first

--- a/sdb/commands/linux_list.py
+++ b/sdb/commands/linux_list.py
@@ -29,27 +29,12 @@ class LinuxList(sdb.Walker):
     names = ["linux_list"]
     input_type = "struct list_head *"
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        parser = argparse.ArgumentParser(description="walk a linux list")
-        parser.add_argument(
-            "offset",
-            default=0,
-            type=int,
-            nargs="?",
-            help="offset of list_head in structure",
-        )
-
-        try:
-            self.args = parser.parse_args(args.split())
-        except SystemExit:
-            #
-            # When the "-h" option is passed, argparse will throw this
-            # exception after the help message is printed. This would
-            # result in the SDB session exiting, which is not what we
-            # want to occur. Thus, we ignore this exception.
-            #
-            pass
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("offset",
+                            default=0,
+                            type=int,
+                            nargs="?",
+                            help="offset of list_head in structure")
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
         node = obj.next

--- a/sdb/commands/member.py
+++ b/sdb/commands/member.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=missing-docstring
 
+import argparse
 from typing import Iterable
 
 import drgn
@@ -31,11 +32,11 @@ class Member(sdb.Command):
         super().__init__(prog, args)
         self.args = args
 
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("members", nargs="+", metavar="<member>")
+
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
-        members = self.args.split()
         for obj in objs:
-            ret_object = obj
-            if members:
-                for i in members:
-                    ret_object = ret_object.member_(i)
-            yield ret_object
+            for member in self.args.members:
+                obj = obj.member_(member)
+            yield obj

--- a/sdb/commands/walk.py
+++ b/sdb/commands/walk.py
@@ -29,10 +29,6 @@ class Walk(sdb.Command):
 
     names = ["walk"]
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        self.args = args
-
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         baked = [(self.prog.type(type_), class_)
                  for type_, class_ in sdb.Walker.allWalkers.items()]

--- a/sdb/commands/zfs/avl.py
+++ b/sdb/commands/zfs/avl.py
@@ -28,20 +28,20 @@ class Avl(sdb.Walker):
     names = ["avl"]
     input_type = "avl_tree_t *"
 
-    def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
-        offset = int(obj.avl_offset)
-        root = obj.avl_root
-        yield from self.helper(root, offset)
-
-    def helper(self, node: drgn.Object, offset: int) -> Iterable[drgn.Object]:
+    def _helper(self, node: drgn.Object, offset: int) -> Iterable[drgn.Object]:
         if node == drgn.NULL(self.prog, node.type_):
             return
 
         lchild = node.avl_child[0]
-        yield from self.helper(lchild, offset)
+        yield from self._helper(lchild, offset)
 
         obj = drgn.Object(self.prog, type="void *", value=int(node) - offset)
         yield obj
 
         rchild = node.avl_child[1]
-        yield from self.helper(rchild, offset)
+        yield from self._helper(rchild, offset)
+
+    def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
+        offset = int(obj.avl_offset)
+        root = obj.avl_root
+        yield from self._helper(root, offset)

--- a/sdb/commands/zfs/internal/__init__.py
+++ b/sdb/commands/zfs/internal/__init__.py
@@ -18,7 +18,6 @@
 # pylint: disable=unnecessary-lambda
 
 import os
-
 from typing import Callable
 
 import drgn

--- a/sdb/commands/zfs/metaslab.py
+++ b/sdb/commands/zfs/metaslab.py
@@ -21,7 +21,6 @@ from typing import Iterable
 
 import drgn
 import sdb
-
 from sdb.commands.zfs.internal import (
     METASLAB_ACTIVE_MASK, METASLAB_WEIGHT_CLAIM, METASLAB_WEIGHT_PRIMARY,
     METASLAB_WEIGHT_SECONDARY, METASLAB_WEIGHT_TYPE, WEIGHT_GET_COUNT,
@@ -33,27 +32,22 @@ class Metaslab(sdb.Locator, sdb.PrettyPrinter):
     input_type = "metaslab_t *"
     output_type = "metaslab_t *"
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "-H",
+            "--histogram",
+            action="store_true",
+            default=False,
+            help="histogram flag",
+        )
 
-        try:
-            parser = argparse.ArgumentParser(prog="metaslab")
-            parser.add_argument(
-                "-H",
-                "--histogram",
-                action="store_true",
-                default=False,
-                help="histogram flag",
-            )
-            parser.add_argument("-w",
-                                "--weight",
-                                action="store_true",
-                                default=False,
-                                help="weight flag")
-            parser.add_argument("metaslab_ids", nargs="*", type=int)
-            self.args = parser.parse_args(args.split())
-        except BaseException:  # pylint: disable=broad-except
-            pass
+        parser.add_argument("-w",
+                            "--weight",
+                            action="store_true",
+                            default=False,
+                            help="weight flag")
+
+        parser.add_argument("metaslab_ids", nargs="*", type=int)
 
     @staticmethod
     def metaslab_weight_print(msp, print_header, indent):

--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -30,37 +30,35 @@ class Spa(sdb.Locator, sdb.PrettyPrinter):
     input_type = "spa_t *"
     output_type = "spa_t *"
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        try:
-            parser = argparse.ArgumentParser(description="spa command")
-            parser.add_argument("-v",
-                                "--vdevs",
-                                action="store_true",
-                                help="vdevs flag")
-            parser.add_argument("-m",
-                                "--metaslab",
-                                action="store_true",
-                                help="metaslab flag")
-            parser.add_argument("-H",
-                                "--histogram",
-                                action="store_true",
-                                help="histogram flag")
-            parser.add_argument("-w",
-                                "--weight",
-                                action="store_true",
-                                help="weight flag")
-            parser.add_argument("poolnames", nargs="*")
-            self.args = parser.parse_args(args.split())
-            self.arg_string = ""
-            if self.args.metaslab:
-                self.arg_string += "-m "
-            if self.args.histogram:
-                self.arg_string += "-H "
-            if self.args.weight:
-                self.arg_string += "-w "
-        except BaseException:  # pylint: disable=broad-except
-            pass
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
+        super().__init__(prog, args, name)
+        self.arg_string = ""
+        if self.args.metaslab:
+            self.arg_string += "-m "
+        if self.args.histogram:
+            self.arg_string += "-H "
+        if self.args.weight:
+            self.arg_string += "-w "
+
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("-v",
+                            "--vdevs",
+                            action="store_true",
+                            help="vdevs flag")
+        parser.add_argument("-m",
+                            "--metaslab",
+                            action="store_true",
+                            help="metaslab flag")
+        parser.add_argument("-H",
+                            "--histogram",
+                            action="store_true",
+                            help="histogram flag")
+        parser.add_argument("-w",
+                            "--weight",
+                            action="store_true",
+                            help="weight flag")
+        parser.add_argument("poolnames", nargs="*")
 
     def pretty_print(self, spas):
         print("{:14} {}".format("ADDR", "NAME"))

--- a/sdb/commands/zfs/vdev.py
+++ b/sdb/commands/zfs/vdev.py
@@ -17,12 +17,10 @@
 # pylint: disable=missing-docstring
 
 import argparse
-
 from typing import Iterable
 
 import drgn
 import sdb
-
 from sdb.commands.zfs.internal import enum_lookup
 from sdb.commands.zfs.metaslab import Metaslab
 
@@ -32,39 +30,39 @@ class Vdev(sdb.Locator, sdb.PrettyPrinter):
     input_type = "vdev_t *"
     output_type = "vdev_t *"
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
+        super().__init__(prog, args, name)
+        self.arg_string = ""
+        if self.args.histogram:
+            self.arg_string += "-H "
+        if self.args.weight:
+            self.arg_string += "-w "
 
-        try:
-            parser = argparse.ArgumentParser(description="vdev command")
-            parser.add_argument(
-                "-m",
-                "--metaslab",
-                action="store_true",
-                default=False,
-                help="metaslab flag",
-            )
-            parser.add_argument(
-                "-H",
-                "--histogram",
-                action="store_true",
-                default=False,
-                help="histogram flag",
-            )
-            parser.add_argument("-w",
-                                "--weight",
-                                action="store_true",
-                                default=False,
-                                help="weight flag")
-            parser.add_argument("vdev_ids", nargs="*", type=int)
-            self.args = parser.parse_args(args.split())
-            self.arg_string = ""
-            if self.args.histogram:
-                self.arg_string += "-H "
-            if self.args.weight:
-                self.arg_string += "-w "
-        except BaseException:  # pylint: disable=broad-except
-            pass
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "-m",
+            "--metaslab",
+            action="store_true",
+            default=False,
+            help="metaslab flag",
+        )
+
+        parser.add_argument(
+            "-H",
+            "--histogram",
+            action="store_true",
+            default=False,
+            help="histogram flag",
+        )
+
+        parser.add_argument("-w",
+                            "--weight",
+                            action="store_true",
+                            default=False,
+                            help="weight flag")
+
+        parser.add_argument("vdev_ids", nargs="*", type=int)
 
     def pretty_print(self, vdevs, indent=0):
         print(

--- a/sdb/commands/zfs/zfs_dbgmsg.py
+++ b/sdb/commands/zfs/zfs_dbgmsg.py
@@ -16,8 +16,8 @@
 
 # pylint: disable=missing-docstring
 
+import argparse
 import datetime
-import getopt
 from typing import Iterable
 
 import drgn
@@ -31,22 +31,8 @@ class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
     input_type = "zfs_dbgmsg_t *"
     output_type = "zfs_dbgmsg_t *"
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
-        self.verbosity = 0
-
-        optlist, args = getopt.getopt(args.split(), "v")
-        if args:
-            print("Improper arguments to ::zfs_dbgmsg: {}\n".format(args))
-            return
-        for (opt, arg) in optlist:
-            if opt != "-v":
-                print("Improper flag to ::zfs_dbgmsg: {}\n".format(opt))
-                return
-            if arg != "":
-                print("Improper value to ::zfs_dbgmsg: {}\n".format(arg))
-                return
-            self.verbosity += 1
+    def _init_argparse(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument('--verbose', '-v', action='count', default=0)
 
     # obj is a zfs_dbgmsg_t*
     @staticmethod
@@ -63,7 +49,8 @@ class ZfsDbgmsg(sdb.Locator, sdb.PrettyPrinter):
 
     def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
         for obj in objs:
-            ZfsDbgmsg.print_msg(obj, self.verbosity >= 1, self.verbosity >= 2)
+            ZfsDbgmsg.print_msg(obj, self.args.verbose >= 1,
+                                self.args.verbose >= 2)
 
     def no_input(self) -> Iterable[drgn.Object]:
         proc_list = self.prog["zfs_dbgmsgs"].pl_list

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -17,6 +17,7 @@
 # pylint: disable=missing-docstring
 
 import readline
+
 import sdb
 
 

--- a/sdb/locator.py
+++ b/sdb/locator.py
@@ -16,8 +16,7 @@
 """This module contains the "sdb.Locator" class."""
 
 import inspect
-
-from typing import Iterable, TypeVar, Callable
+from typing import Callable, Iterable, TypeVar
 
 import drgn
 import sdb
@@ -35,8 +34,9 @@ class Locator(sdb.Command):
 
     output_type: str = ""
 
-    def __init__(self, prog: drgn.Program, args: str = "") -> None:
-        super().__init__(prog, args)
+    def __init__(self, prog: drgn.Program, args: str = "",
+                 name: str = "_") -> None:
+        super().__init__(prog, args, name)
         # We unset the input_type here so that the pipeline doesn't add a
         # coerce before us and ruin our ability to dispatch based on multiple
         # input types. For pure locators, and input_type wouldn't be set, but

--- a/tests/commands/test_echo.py
+++ b/tests/commands/test_echo.py
@@ -114,8 +114,8 @@ def test9():
     assert ret[0].value_() == 0
     assert ret[0].type_ == tprog.type('void *')
     assert ret[1].value_() == 1
-    assert ret[1].type_ == tprog.type('void *')
+    assert ret[1].type_ == tprog.type('int')
     assert ret[2].value_() == 0
     assert ret[2].type_ == tprog.type('void *')
     assert ret[3].value_() == 1
-    assert ret[3].type_ == tprog.type('int')
+    assert ret[3].type_ == tprog.type('void *')


### PR DESCRIPTION
This change updates all of the commands to consistently use "argparse"
for argument parsing; and the "Command" class has been modified to
enforce this.

Now, when a "Command" object is created, it will create an argument
parser that doesn't have any supported arguments. If a specific command
wishes to support arguments, that command's class must implement the
"_init_argparse" method, to add its supported arguments to the parser.