### PR TITLE
Bleeding edge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 
 script:
   - yapf --diff --style google --recursive sdb
+  - yapf --diff --style google --recursive tests
   - pylint -d duplicate-code sdb
   - pytest -v tests
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -14,11 +14,11 @@ $ python3 -m pip install pytest
 $ python3 -m pytest
 ```
 
-* [Black](https://black.readthedocs.io)
+* [yapf](https://github.com/google/yapf)
 ```
 $ python3 -m pip install black
 $ python3 -m black sdb
 ```
 
-`pylint`, `isort`, and `yapf` are also used to some extend, but are not
-required yet as there is still a lot of noise.
+`pylint`, `mypy`, and `isort` are also used to some extend, but
+are not required yet as there is still a lot of noise.

--- a/sdb/command.py
+++ b/sdb/command.py
@@ -34,7 +34,22 @@ class Command:
 
     # pylint: disable=too-few-public-methods
 
+    #
+    # names:
+    #    The potential names that can be used to invoke
+    #    the command.
+    #
     names: List[str] = []
+
+    #
+    # name:
+    #    The name used when the command was invoked. This
+    #    is generally used as a parameter passed to
+    #    exceptions raised by SDB to make error messages
+    #    more precise.
+    #
+    name: str = ""
+
     input_type: Optional[str] = None
 
     def __init__(self, prog: drgn.Program, args: str = "",

--- a/sdb/commands/echo.py
+++ b/sdb/commands/echo.py
@@ -36,4 +36,8 @@ class Echo(sdb.Command):
             yield obj
 
         for addr in self.args.addrs:
-            yield drgn.Object(self.prog, "void *", value=int(addr, 0))
+            try:
+                value_ = int(addr, 0)
+            except ValueError:
+                raise sdb.CommandInvalidInputError(self.name, addr)
+            yield drgn.Object(self.prog, "void *", value=value_)

--- a/sdb/commands/member.py
+++ b/sdb/commands/member.py
@@ -34,5 +34,13 @@ class Member(sdb.Command):
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         for obj in objs:
             for member in self.args.members:
-                obj = obj.member_(member)
+                try:
+                    obj = obj.member_(member)
+                except (LookupError, TypeError) as err:
+                    #
+                    # The expected error messages that we get from
+                    # member_() are good enough to be propagated
+                    # as-is.
+                    #
+                    raise sdb.CommandError(self.name, str(err))
             yield obj

--- a/sdb/error.py
+++ b/sdb/error.py
@@ -1,0 +1,83 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""This module contains the "sdb.Error" exception."""
+
+
+class Error(Exception):
+    """
+    This is the superclass of all SDB error exceptions.
+    """
+
+    text: str = ""
+
+    def __init__(self, text: str) -> None:
+        self.text = 'sdb: {}'.format(text)
+        super().__init__(self.text)
+
+
+class CommandNotFoundError(Error):
+    # pylint: disable=too-few-public-methods
+    # pylint: disable=missing-docstring
+
+    command: str = ""
+
+    def __init__(self, command: str) -> None:
+        self.command = command
+        super().__init__('cannot recognize command: {}'.format(command))
+
+
+class CommandError(Error):
+    # pylint: disable=too-few-public-methods
+    # pylint: disable=missing-docstring
+
+    command: str = ""
+    message: str = ""
+
+    def __init__(self, command: str, message: str) -> None:
+        self.command = command
+        self.message = message
+        super().__init__('{}: {}'.format(command, message))
+
+
+class CommandInvalidInputError(CommandError):
+    # pylint: disable=too-few-public-methods
+    # pylint: disable=missing-docstring
+
+    argument: str = ""
+
+    def __init__(self, command: str, argument: str) -> None:
+        self.argument = argument
+        super().__init__(command, 'invalid input: {}'.format(argument))
+
+
+class SymbolNotFoundError(CommandError):
+    # pylint: disable=too-few-public-methods
+    # pylint: disable=missing-docstring
+
+    symbol: str = ""
+
+    def __init__(self, command: str, symbol: str) -> None:
+        self.symbol = symbol
+        super().__init__(command, 'symbol not found: {}'.format(symbol))
+
+
+class CommandArgumentsError(CommandError):
+    # pylint: disable=too-few-public-methods
+    # pylint: disable=missing-docstring
+
+    def __init__(self, command: str) -> None:
+        super().__init__(command,
+                         'invalid input. Use -h to get argument description')

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -74,6 +74,15 @@ class REPL:
                 for obj in objs:
                     print(obj)
 
+            except sdb.CommandArgumentsError:
+                #
+                # We skip printing anything for this specific error
+                # as argparse should have already printed a helpful
+                # message to the REPL for us.
+                #
+                continue
+            except sdb.Error as err:
+                print(err.text)
             except (EOFError, KeyboardInterrupt):
                 print(self.closing)
                 break

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,140 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+from typing import Iterable, List, Optional
+
+import drgn
+import sdb
+
+
+def create_struct_type(name: str, member_names: List[str],
+                       member_types: List[drgn.Type]) -> drgn.Type:
+    """
+    Creates a structure type given a list of member names and
+    a list of types like this:
+    ```
+    create_struct_type(<name>, [<name_a>, <name_b> ...],
+                       [<type_a>, <type_b>, ...])
+    ```
+    returns a C structure:
+    ```
+    struct <name> {
+      type_a name_a;
+      type_b name_b;
+      ...
+    };
+    ```
+    """
+    assert len(member_names) == len(member_types)
+    struct_size, bit_offset = 0, 0
+    member_list = []
+    for member_name, type_ in zip(member_names, member_types):
+        member_tuple = (type_, member_name, bit_offset, 0)
+        member_list.append(member_tuple)
+        bit_offset += 8 * struct_size
+        struct_size += type_.size
+    return drgn.struct_type(name, struct_size, member_list)
+
+
+def setup_basic_mock_program() -> drgn.Program:
+    #
+    # We specify an architecture here so we can have consistent
+    # results through explicit assumptions like size of pointers
+    # and representation of integers.
+    #
+    platform = drgn.Platform(
+        drgn.Architecture.X86_64,
+        drgn.PlatformFlags.IS_LITTLE_ENDIAN | drgn.PlatformFlags.IS_64_BIT)
+    prog = drgn.Program(platform)
+
+    #
+    # We create these types BEFORE registering the type callback
+    # below and outside of the callback itself but access them
+    # thorugh the closure of the outer function. This is because
+    # calling prog.type() from within the callback itself can
+    # lead to infinite recursion, and not using prog from withing
+    # the callback means that we'd need to recreate basic types
+    # like int and void *.
+    #
+    int_type = prog.type('int')
+    voidp_type = prog.type('void *')
+    struct_type = create_struct_type('test_struct', ['ts_int', 'ts_voidp'],
+                                     [int_type, voidp_type])
+
+    def mock_type_find(kind: drgn.TypeKind, name: str,
+                       filename: Optional[str]) -> Optional[drgn.Type]:
+        assert filename is None
+        mocked_types = {
+            'test_struct': struct_type,
+        }
+        if name in mocked_types:
+            return mocked_types[name]
+        return None
+
+    prog.add_type_finder(mock_type_find)
+
+    global_struct_addr = 0xffffffffc0a8aee0
+
+    def mock_object_find(prog: drgn.Program, name: str,
+                         flags: drgn.FindObjectFlags,
+                         filename: Optional[str]) -> Optional[drgn.Object]:
+        assert filename is None
+        assert flags == drgn.FindObjectFlags.ANY
+
+        mock_objects = {
+            'global_int': (int_type, 0xffffffffc0a8aee0),
+            'global_void_ptr': (voidp_type, 0xffff88d26353c108),
+            'global_struct': (struct_type, global_struct_addr),
+        }
+
+        if name in mock_objects:
+            type_, addr = mock_objects[name]
+            return drgn.Object(prog, type=type_, address=addr)
+        return None
+
+    prog.add_object_finder(mock_object_find)
+
+    def fake_memory_reader(address: int, count: int, physical: int,
+                           offset: bool) -> bytes:
+        assert address == physical
+        assert not offset
+        fake_mappings = {
+            # address of global_struct and its first member ts_int
+            global_struct_addr: b'\x01\x00\x00\x00'
+        }
+        assert address in fake_mappings
+        return fake_mappings[address]
+
+    prog.add_memory_segment(0, 0xffffffffffffffff, fake_memory_reader)
+    return prog
+
+
+#
+# Basic mock program to be used by the very primitive commands
+# like echo, address, member, cast, head, tail, filter, and help.
+#
+tprog = setup_basic_mock_program()
+
+
+def invoke(prog: drgn.Program, objs: Iterable[drgn.Object],
+           line: str) -> Iterable[drgn.Object]:
+    """
+    Dispatch to sdb.invoke, but also drain the generator it returns, so
+    the tests can more easily access the returned objects.
+    """
+    return [i for i in sdb.invoke(prog, objs, line)]

--- a/tests/commands/test_address.py
+++ b/tests/commands/test_address.py
@@ -1,0 +1,106 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import pytest
+import sdb
+
+from tests import invoke, tprog
+
+
+def test_empty():
+    line = 'address'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert not ret
+
+
+def test_single_object():
+    line = 'addr global_int'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].value_() == 0xffffffffc0a8aee0
+    assert ret[0].type_ == tprog.type('int *')
+
+
+def test_plain_address():
+    line = 'addr 0xffffffffc084eee0'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0].value_() == 0xffffffffc084eee0
+    assert ret[0].type_ == tprog.type('void *')
+
+
+def test_multiple_object():
+    line = 'addr global_int 0xffffffffc084eee0 global_void_ptr'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert len(ret) == 3
+    assert ret[0].value_() == 0xffffffffc0a8aee0
+    assert ret[0].type_ == tprog.type('int *')
+    assert ret[1].value_() == 0xffffffffc084eee0
+    assert ret[1].type_ == tprog.type('void *')
+    assert ret[2].value_() == 0xffff88d26353c108
+    assert ret[2].type_ == tprog.type('void **')
+
+
+def test_piped_invocations():
+    line = 'addr global_int | addr 0xffffffffc084eee0 global_void_ptr'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert len(ret) == 3
+    assert ret[0].value_() == 0xffffffffc0a8aee0
+    assert ret[0].type_ == tprog.type('int *')
+    assert ret[1].value_() == 0xffffffffc084eee0
+    assert ret[1].type_ == tprog.type('void *')
+    assert ret[2].value_() == 0xffff88d26353c108
+    assert ret[2].type_ == tprog.type('void **')
+
+
+def test_echo_pipe():
+    line = 'addr 0xffffffffc084eee0 | addr global_void_ptr'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert len(ret) == 2
+    assert ret[0].value_() == 0xffffffffc084eee0
+    assert ret[0].type_ == tprog.type('void *')
+    assert ret[1].value_() == 0xffff88d26353c108
+    assert ret[1].type_ == tprog.type('void **')
+
+
+def test_global_not_found():
+    line = 'addr bogus'
+    objs = []
+
+    with pytest.raises(sdb.SymbolNotFoundError) as err:
+        invoke(tprog, objs, line)
+
+    assert err.value.symbol == 'bogus'

--- a/tests/commands/test_member.py
+++ b/tests/commands/test_member.py
@@ -1,0 +1,70 @@
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=missing-docstring
+
+import drgn
+import pytest
+import sdb
+
+from tests import invoke, tprog
+
+
+def test_no_arg():
+    line = 'member'
+    objs = []
+
+    with pytest.raises(sdb.CommandArgumentsError):
+        invoke(tprog, objs, line)
+
+
+def test_arg_no_pipe_input():
+    line = 'member int_member'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert not ret
+
+
+def test_scalar_input():
+    line = 'addr global_int | member int_member'
+    objs = []
+
+    with pytest.raises(sdb.CommandError) as err:
+        invoke(tprog, objs, line)
+
+    assert "'int' is not a structure or union" in str(err.value)
+
+
+def test_member_not_found():
+    line = 'addr global_struct | member bogus'
+    objs = []
+
+    with pytest.raises(sdb.CommandError) as err:
+        invoke(tprog, objs, line)
+
+    assert "'struct test_struct' has no member 'bogus'" in str(err.value)
+
+
+def test_one_member():
+    line = 'addr global_struct | member ts_int'
+    objs = []
+
+    ret = invoke(tprog, objs, line)
+
+    assert len(ret) == 1
+    assert ret[0] == drgn.Object(tprog, tprog.type('int'), value=1)


### PR DESCRIPTION
= Commit Notes =
testing:
- rename echo tests
- add address tests
- type callback + member tests
- fake memory reader

refactor:
- towards legit error handling
- adapth echo and address commands
- uncaught exceptions can now crash the repl
- adjust bogus tests to expect exceptions
- add preliminary pipe tests for echo and address
- repl catches all SDB related errors
- tprog testing infrastructure as common code
- one_member test object equality

fix:
- member command passed scalar input throws error instead of crashing
- member command passed bogus member throws error instead of crashing
- pyfilter handle SyntaxError and TypeError

style:
- yapf format the tests directory
- pylint test directory
- add License text in test files

travis:
- add yapf checks for testing directory

doc:
- no longer using black

= Example Output =

* Command not found:
```
> dawefasdf
sdb: cannot recognize command: dawefasdf
```

* Incorrect arguments passed to command's argparse
```
> member
usage: member [-h] <member> [<member> ...]
member: error: the following arguments are required: <member>
```

*  Handle incorrect input to echo
```
> echo asdf
sdb: echo: invalid input: asdf
```

* Handle symbol not found in address command
```
> address as3
sdb: address: symbol not found: as3
```

* Always print the command name used in the error message
```
> echo asdf
sdb: echo: invalid input: asdf
> cc asdf
sdb: cc: invalid input: asdf
> addr as2
sdb: addr: symbol not found: as2
> address as3
sdb: address: symbol not found: as3
```

* Handle drgn value-objects uniformly in address command
```
> echo 10 | addr
(void *)0xa
```

* Handle scalar types passed to member command
```
> addr zfs_flags | member test
sdb: member: 'int' is not a structure or union
```

* Handle incorrect member for member command
```
> addr spa_namespace_avl | member avl_raat
sdb: member: 'avl_tree_t' has no member 'avl_raat'
```

* Handle pyfilter syntax error:
```
>  echo 0 1 | pyfilter obj.address_ asdf asdf
sdb: pyfilter: invalid syntax:
	obj.address_ asdf asdf
	                ^
>
```

* Handle pyfilter attribute error:
```
> echo 0 1 | pyfilter obj.addres
sdb: pyfilter: '_drgn.Object' object has no attribute 'addres'
```

* Handle pyfilter type error:
```
> echo 0 1 | pyfilter obj == 0
sdb: pyfilter: invalid operands to comparison ('void *' and 'int')
```