### PR TITLE
session: Add session recording & replay functionality

### DIFF
--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -23,6 +23,7 @@ import argparse
 import os
 import re
 import sys
+import zipfile
 
 from typing import List
 
@@ -30,6 +31,7 @@ import drgn
 import sdb
 from sdb.internal.repl import REPL
 from sdb.mdb_compat import set_mdb_compat_enabled
+from sdb.session import get_trace_manager, TraceManager
 
 try:
     from sdb._version import version, commit_id
@@ -117,6 +119,22 @@ def parse_arguments() -> argparse.Namespace:
         action="store_false",
         help="disable mdb compatibility syntax (symbol::cmd)",
     )
+
+    # Session recording and replay
+    session_group = parser.add_argument_group("session recording")
+    session_group.add_argument(
+        "--record",
+        metavar="FILE",
+        type=str,
+        help="record session to FILE.sdb (memory accesses, objects, symbols)",
+    )
+    session_group.add_argument(
+        "--replay",
+        metavar="FILE",
+        type=str,
+        help="replay a recorded session from FILE.sdb",
+    )
+
     args = parser.parse_args()
 
     #
@@ -147,6 +165,23 @@ def parse_arguments() -> argparse.Namespace:
     #
     if args.object and not args.core:
         parser.error("raw object file target is not supported yet")
+
+    #
+    # Replay mode is mutually exclusive with other target options
+    #
+    if args.replay:
+        if args.object or args.core:
+            parser.error("cannot specify object/core files with --replay")
+        if args.kernel:
+            parser.error("cannot specify --kernel with --replay")
+        if args.pid:
+            parser.error("cannot specify --pid with --replay")
+
+    #
+    # Recording requires a target (can't record nothing)
+    #
+    if args.record and args.replay:
+        parser.error("cannot use --record and --replay together")
 
     return args
 
@@ -250,13 +285,108 @@ def setup_target(args: argparse.Namespace) -> drgn.Program:
     return prog
 
 
-def main() -> None:
-    """The entry point of the sdb "executable" """
-    args = parse_arguments()
+def setup_replay_target(replay_path: str, symbol_search: List[str],
+                        quiet: bool) -> drgn.Program:
+    """
+    Setup a drgn.Program for replay mode from a recorded session bundle.
 
-    # Configure mdb compatibility syntax preprocessing
-    set_mdb_compat_enabled(args.mdb_compat)
+    The bundle provides memory contents, while debug info must still be
+    loaded from the original vmlinux/modules (specified via -s).
+    """
+    # Load the bundle
+    trace_mgr = get_trace_manager()
+    try:
+        # Load the bundle into the trace manager
+        loaded_mgr = TraceManager.load_bundle(replay_path)
+        # Copy state to global manager
+        trace_mgr.is_replay = True
+        trace_mgr.memory = loaded_mgr.memory
+        trace_mgr.objects = loaded_mgr.objects
+        trace_mgr.symbols = loaded_mgr.symbols
+        trace_mgr.threads = loaded_mgr.threads
+        trace_mgr.metadata = loaded_mgr.metadata
+    except FileNotFoundError:
+        print(f"sdb: no such file: '{replay_path}'")
+        sys.exit(2)
+    except (ValueError, OSError, zipfile.BadZipFile) as e:
+        print(f"sdb: failed to load replay bundle: {e}")
+        sys.exit(1)
 
+    # Set up platform from metadata
+    metadata = trace_mgr.metadata
+    arch_name = metadata.get('arch', 'unknown')
+    flags_value = metadata.get('flags', 0)
+
+    # Create the program with platform if available
+    platform = None
+    if arch_name != 'unknown':
+        try:
+            arch = getattr(drgn.Architecture, arch_name)
+            flags = drgn.PlatformFlags(flags_value)
+            platform = drgn.Platform(arch, flags)
+        except (AttributeError, ValueError) as e:
+            if not quiet:
+                print(
+                    f"sdb: warning: could not create platform from metadata: {e}",
+                    file=sys.stderr)
+
+    if platform:
+        prog = drgn.Program(platform)
+    else:
+        # Default to x86_64 Linux for kernel debugging
+        prog = drgn.Program(drgn.Platform(drgn.Architecture.X86_64))
+
+    # Load debug info first - this sets up types and platform info
+    if symbol_search:
+        try:
+            load_debug_info(prog, symbol_search, quiet, False)
+        except (drgn.MissingDebugInfoError, OSError) as debug_info_err:
+            if not quiet:
+                print("sdb: " + str(debug_info_err), file=sys.stderr)
+
+    # Set up the memory reader
+    def memory_reader(address: int, count: int, _offset: int,
+                      _physical: bool) -> bytes:
+        return trace_mgr.memory.read(address, count)
+
+    # Register for the full address space
+    prog.add_memory_segment(0, 0xFFFFFFFFFFFFFFFF, memory_reader)
+
+    return prog
+
+
+def _run_replay_mode(args: argparse.Namespace) -> None:
+    """Handle replay mode execution."""
+    try:
+        prog = setup_replay_target(args.replay, args.symbol_search, args.quiet)
+    except PermissionError as err:
+        print("sdb: " + str(err))
+        return
+
+    sdb.target.set_prog(prog)
+    # In replay mode, we don't have real threads
+    # Set a dummy thread value
+    sdb.target.set_thread(0)
+    sdb.target.set_frame(-1)
+    sdb.register_commands()
+
+    if not args.quiet:
+        trace_mgr = get_trace_manager()
+        status = trace_mgr.get_status()
+        print(f"Replay mode: loaded {status['memory_size']} bytes "
+              f"in {status['memory_segments']} segments")
+
+    repl = REPL(prog, list(sdb.get_registered_commands().keys()))
+    repl.enable_history(os.getenv("SDB_HISTORY_FILE", "~/.sdb_history"))
+    if args.eval:
+        exit_code = repl.eval_cmd(args.eval)
+        sys.exit(exit_code)
+    else:
+        repl.start_session()
+
+
+def _run_normal_mode(args: argparse.Namespace) -> None:
+    """Handle normal (live or crash dump) mode execution."""
     try:
         prog = setup_target(args)
     except PermissionError as err:
@@ -270,13 +400,59 @@ def main() -> None:
     sdb.target.set_frame(-1)
     sdb.register_commands()
 
+    # Handle recording mode
+    if args.record:
+        trace_mgr = get_trace_manager()
+        trace_mgr.start_recording(prog, args.record)
+        if not args.quiet:
+            print(f"Recording to: {args.record}")
+
     repl = REPL(prog, list(sdb.get_registered_commands().keys()))
     repl.enable_history(os.getenv("SDB_HISTORY_FILE", "~/.sdb_history"))
-    if args.eval:
-        exit_code = repl.eval_cmd(args.eval)
-        sys.exit(exit_code)
-    else:
-        repl.start_session()
+
+    try:
+        if args.eval:
+            exit_code = repl.eval_cmd(args.eval)
+            # If recording, stop and save
+            if args.record:
+                _stop_recording_if_active(prog, args.quiet)
+            sys.exit(exit_code)
+        else:
+            repl.start_session()
+    finally:
+        # If recording was active and we're exiting, save it
+        if args.record:
+            _stop_recording_if_active(prog, args.quiet, newline=True)
+
+
+def _stop_recording_if_active(prog: drgn.Program,
+                              quiet: bool,
+                              newline: bool = False) -> None:
+    """Stop recording if it's active and print status."""
+    trace_mgr = get_trace_manager()
+    if trace_mgr.is_recording:
+        saved_path = trace_mgr.stop_recording(prog)
+        if not quiet:
+            status = trace_mgr.get_status()
+            prefix = "\n" if newline else ""
+            print(f"{prefix}Recording saved to: {saved_path}")
+            print(f"  Memory: {status['memory_size']} bytes")
+
+
+def main() -> None:
+    """The entry point of the sdb "executable" """
+    args = parse_arguments()
+
+    # Configure mdb compatibility syntax preprocessing
+    set_mdb_compat_enabled(args.mdb_compat)
+
+    # Handle replay mode
+    if args.replay:
+        _run_replay_mode(args)
+        return
+
+    # Normal mode (live or crash dump)
+    _run_normal_mode(args)
 
 
 if __name__ == "__main__":

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -19,12 +19,14 @@
 import atexit
 import os
 import readline
+import shlex
 import traceback
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 import drgn
 from sdb.error import Error, CommandArgumentsError
 from sdb.pipeline import invoke
+from sdb.session import get_trace_manager
 
 
 class REPL:
@@ -96,6 +98,167 @@ class REPL:
         readline.set_history_length(1000)
         atexit.register(readline.write_history_file, self.histfile)
 
+    def _parse_session_cmd(self, input_: str) -> Tuple[str, List[str]]:
+        """Parse session command input into subcmd and args."""
+        parts = shlex.split(input_)
+        if not parts or parts[0] != 'session':
+            return ('', parts)
+        if len(parts) < 2:
+            return ('', parts)
+        return (parts[1], parts[2:])
+
+    def _handle_session_record(self, args: List[str]) -> int:
+        """Handle %session record command."""
+        if not args:
+            print("Usage: %session record <file.sdb>")
+            return 2
+        output_path = args[0]
+        trace_mgr = get_trace_manager()
+        trace_mgr.start_recording(self.target, output_path)
+        print(f"Recording started. Output will be saved to: {output_path}")
+        return 0
+
+    def _handle_session_stop(self) -> int:
+        """Handle %session stop command."""
+        trace_mgr = get_trace_manager()
+        saved_path = trace_mgr.stop_recording(self.target)
+        status = trace_mgr.get_status()
+        print("Recording stopped.")
+        print(f"Saved to: {saved_path}")
+        print(f"  Memory segments: {status['memory_segments']}")
+        print(f"  Memory size: {status['memory_size']} bytes")
+        print(f"  Objects: {status['objects_count']}")
+        print(f"  Symbols: {status['symbols_count']}")
+        return 0
+
+    def _handle_session_status(self) -> int:
+        """Handle %session status command."""
+        trace_mgr = get_trace_manager()
+        status = trace_mgr.get_status()
+        if status['is_recording']:
+            print(f"Recording to: {status['output_path']}")
+            print(f"  Memory segments: {status['memory_segments']}")
+            print(f"  Memory size: {status['memory_size']} bytes")
+            print(f"  Objects: {status['objects_count']}")
+        elif status['is_replay']:
+            print("Replay mode active")
+            print(f"  Memory segments: {status['memory_segments']}")
+            print(f"  Memory size: {status['memory_size']} bytes")
+        else:
+            print("No recording or replay in progress")
+        return 0
+
+    def _handle_session_snapshot(self, args: List[str]) -> int:
+        """Handle %session snapshot command."""
+        if not args:
+            print("Usage: %session snapshot <variable> [--depth N]")
+            return 2
+        var_name = args[0]
+        depth = 1
+        if len(args) >= 3 and args[1] == '--depth':
+            try:
+                depth = int(args[2])
+            except ValueError:
+                print(f"Invalid depth: {args[2]}")
+                return 2
+
+        trace_mgr = get_trace_manager()
+        if not trace_mgr.is_recording:
+            print(
+                "Error: No recording in progress. Use '%session record <file>' first."
+            )
+            return 1
+
+        # Force read the variable to capture it
+        try:
+            import sdb.target as sdb_target  # pylint: disable=import-outside-toplevel
+            obj = sdb_target.get_object(var_name)
+            # Use capture_object for proper tracing
+            trace_mgr.capture_object(obj, depth)
+            # Also record the named object
+            trace_mgr.record_object(var_name, int(obj.address_of_()),
+                                    str(obj.type_))
+            status = trace_mgr.get_status()
+            print(f"Snapshot captured: {var_name}")
+            print(f"  Memory segments: {status['memory_segments']}")
+            print(f"  Memory size: {status['memory_size']} bytes")
+        except (drgn.FaultError, ValueError, TypeError, LookupError) as e:
+            print(f"Failed to snapshot {var_name}: {e}")
+            return 1
+        return 0
+
+    def _handle_session_load(self, args: List[str]) -> int:
+        """Handle %session load command."""
+        if not args:
+            print("Usage: %session load <file.sdb>")
+            return 2
+        # Note: Loading is primarily done via CLI --replay
+        # This command is for switching to a loaded session
+        print("Note: Use 'sdb --replay <file.sdb>' to load a recorded session")
+        print("      The %session load command is for advanced use cases")
+        return 0
+
+    # pylint: disable=too-many-return-statements
+    def eval_session_cmd(self, input_: str) -> int:
+        """
+        Evaluates a session command (commands starting with %).
+
+        Session commands control recording and replay functionality:
+        - %session record <file.sdb> - Start recording
+        - %session stop - Stop recording and save
+        - %session status - Show recording status
+        - %session snapshot <var> [--depth N] - Capture object graph
+        - %session load <file.sdb> - Load a recorded session
+
+        Returns:
+            0 for success
+            1 for error
+            2 for incorrect arguments
+        """
+        try:
+            # Parse the session command
+            parts = shlex.split(input_)
+            if not parts:
+                print("Usage: %session <command> [args]")
+                print("Commands: record, stop, status, snapshot, load")
+                return 2
+
+            if parts[0] != 'session':
+                print(f"Unknown meta-command: %{parts[0]}")
+                print("Available meta-commands: %session")
+                return 1
+
+            if len(parts) < 2:
+                print("Usage: %session <command> [args]")
+                print("Commands: record, stop, status, snapshot, load")
+                return 2
+
+            subcmd = parts[1]
+            args = parts[2:]
+
+            if subcmd == 'record':
+                return self._handle_session_record(args)
+            if subcmd == 'stop':
+                return self._handle_session_stop()
+            if subcmd == 'status':
+                return self._handle_session_status()
+            if subcmd == 'snapshot':
+                return self._handle_session_snapshot(args)
+            if subcmd == 'load':
+                return self._handle_session_load(args)
+
+            print(f"Unknown session command: {subcmd}")
+            print("Commands: record, stop, status, snapshot, load")
+            return 1
+
+        except RuntimeError as e:
+            print(f"Session error: {e}")
+            return 1
+        except (ValueError, TypeError, OSError) as e:
+            print(f"Session command failed: {e}")
+            return 1
+
+    # pylint: disable=too-many-return-statements
     def eval_cmd(self, input_: str) -> int:
         """
         Evaluates the SDB command/pipeline passed as input_
@@ -106,9 +269,24 @@ class REPL:
             1 for error
             2 for incorrect arguments passed
         """
+        # Check for session/meta commands (starting with %)
+        if input_.startswith('%'):
+            return self.eval_session_cmd(input_[1:])
+
+        # Check if recording is active
+        trace_mgr = get_trace_manager()
+        is_tracing = trace_mgr.is_recording
+
         # pylint: disable=broad-except
         try:
             for obj in invoke([], input_):
+                # If recording, capture the object's memory
+                if is_tracing and hasattr(obj, 'address_of_'):
+                    try:
+                        trace_mgr.capture_object(obj, depth=0)
+                    except Exception:
+                        pass  # Don't let tracing errors break commands
+
                 try:
                     print(obj.format_(dereference=False))
                 except AttributeError:

--- a/sdb/session.py
+++ b/sdb/session.py
@@ -1,0 +1,663 @@
+#
+# Copyright 2025 CoreWeave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Session recording and replay functionality for SDB.
+
+This module provides the ability to record SDB debugging sessions (memory
+accesses, objects, symbols) into a portable .sdb bundle file, and replay
+those sessions offline without the original crash dump.
+
+The .sdb bundle is a ZIP archive containing:
+- metadata.json: Version, timestamp, original dump info
+- memory.bin.gz: Gzip-compressed binary memory trace
+- objects.json: Object name to address/type mapping
+- symbols.json: Address to symbol name mapping
+- threads.json: Thread ID to stack PCs for stack trace replay
+"""
+
+# pylint: disable=too-many-lines
+
+import gzip
+import json
+import struct
+import zipfile
+from bisect import bisect_right
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import drgn
+from drgn import TypeKind
+
+# Bundle file format constants
+BUNDLE_VERSION = 1
+MEMORY_MAGIC = b'SMEM'  # SDB MEMory
+MEMORY_VERSION = 1
+
+# Fat read alignment (256 bytes as per design decision)
+FAT_READ_ALIGNMENT = 256
+FAT_READ_MASK = ~(FAT_READ_ALIGNMENT - 1)
+
+
+@dataclass
+class MemoryRecord:
+    """A single memory read record."""
+    address: int
+    data: bytes
+    seq_id: int = 0
+
+
+@dataclass
+class ObjectRecord:
+    """A recorded object with its address and type."""
+    name: str
+    address: int
+    type_name: str
+
+
+@dataclass
+class SymbolRecord:
+    """A recorded symbol with its address range."""
+    name: str
+    address: int
+    size: int = 0
+
+
+@dataclass
+class ThreadRecord:
+    """A recorded thread's stack trace as program counters."""
+    tid: int
+    pcs: List[int] = field(default_factory=list)
+
+
+class SparseMemory:
+    """
+    A sparse memory backend that stores disjoint memory segments.
+
+    Uses last-write-wins semantics for overlapping regions during loading.
+    Segments are kept sorted by address for efficient binary search lookups.
+    """
+
+    def __init__(self) -> None:
+        # List of (start_addr, end_addr, data) tuples, sorted by start_addr
+        self.segments: List[Tuple[int, int, bytes]] = []
+
+    def write(self, address: int, data: bytes) -> None:
+        """
+        Write data to the sparse memory, handling overlaps with last-write-wins.
+        """
+        if not data:
+            return
+
+        new_start = address
+        new_end = address + len(data)
+
+        # Find and handle overlapping segments
+        # Remove segments that are completely covered
+        # Trim segments that partially overlap
+        new_segments: List[Tuple[int, int, bytes]] = []
+
+        for seg_start, seg_end, seg_data in self.segments:
+            if seg_end <= new_start or seg_start >= new_end:
+                # No overlap, keep as-is
+                new_segments.append((seg_start, seg_end, seg_data))
+            else:
+                # Overlap exists - trim or split the old segment
+                # Keep part before new write
+                if seg_start < new_start:
+                    keep_len = new_start - seg_start
+                    new_segments.append(
+                        (seg_start, new_start, seg_data[:keep_len]))
+
+                # Keep part after new write
+                if seg_end > new_end:
+                    skip_len = new_end - seg_start
+                    new_segments.append((new_end, seg_end, seg_data[skip_len:]))
+
+        # Add the new segment
+        new_segments.append((new_start, new_end, data))
+
+        # Sort by start address
+        new_segments.sort(key=lambda x: x[0])
+        self.segments = new_segments
+
+    # pylint: disable=too-many-locals
+    def read(self, address: int, size: int) -> bytes:
+        """
+        Read data from sparse memory.
+
+        Raises FaultError if any requested byte is not in the recorded memory.
+        """
+        if size == 0:
+            return b''
+
+        result = bytearray(size)
+        end_address = address + size
+
+        # Find segments that might contain our data
+        # Use binary search for efficiency
+        starts = [s[0] for s in self.segments]
+
+        # Find the first segment that could contain our start address
+        idx = bisect_right(starts, address) - 1
+        idx = max(idx, 0)
+
+        bytes_filled = 0
+        coverage = [False] * size
+
+        while idx < len(self.segments) and bytes_filled < size:
+            seg_start, seg_end, seg_data = self.segments[idx]
+
+            if seg_start >= end_address:
+                break
+
+            if seg_end <= address:
+                idx += 1
+                continue
+
+            # Calculate overlap
+            overlap_start = max(address, seg_start)
+            overlap_end = min(end_address, seg_end)
+
+            if overlap_start < overlap_end:
+                # Copy overlapping data
+                result_offset = overlap_start - address
+                data_offset = overlap_start - seg_start
+                copy_len = overlap_end - overlap_start
+
+                result[result_offset:result_offset +
+                       copy_len] = seg_data[data_offset:data_offset + copy_len]
+
+                for i in range(result_offset, result_offset + copy_len):
+                    if not coverage[i]:
+                        coverage[i] = True
+                        bytes_filled += 1
+
+            idx += 1
+
+        # Check if all bytes were found
+        if bytes_filled < size:
+            missing_ranges = self._find_missing_ranges(coverage, address)
+            msg = f"Memory not in trace: {missing_ranges[0] if missing_ranges else hex(address)}"
+            raise drgn.FaultError(msg, address)
+
+        return bytes(result)
+
+    def _find_missing_ranges(self, coverage: List[bool],
+                             base_addr: int) -> List[str]:
+        """Find ranges of missing bytes for error reporting."""
+        ranges = []
+        start = None
+        for i, covered in enumerate(coverage):
+            if not covered and start is None:
+                start = i
+            elif covered and start is not None:
+                ranges.append(
+                    f"{hex(base_addr + start)}-{hex(base_addr + i - 1)}")
+                start = None
+        if start is not None:
+            ranges.append(
+                f"{hex(base_addr + start)}-{hex(base_addr + len(coverage) - 1)}"
+            )
+        return ranges
+
+    def get_total_size(self) -> int:
+        """Return total bytes stored in sparse memory."""
+        return sum(len(data) for _, _, data in self.segments)
+
+    def get_segment_count(self) -> int:
+        """Return number of disjoint segments."""
+        return len(self.segments)
+
+
+# pylint: disable=too-many-instance-attributes
+class TraceManager:
+    """
+    Manages session recording state and memory tracing.
+
+    This class handles:
+    - Installing/uninstalling memory read hooks
+    - Buffering memory reads with fat read alignment
+    - Recording objects, symbols, and thread stacks
+    - Saving and loading .sdb bundle files
+    """
+
+    def __init__(self) -> None:
+        self.is_recording = False
+        self.is_replay = False
+        self.output_path: Optional[str] = None
+        self.original_read: Optional[Callable[..., bytes]] = None
+        self._recording_prog: Optional[drgn.Program] = None
+
+        # Recording buffers
+        self.memory = SparseMemory()
+        self.objects: Dict[str, ObjectRecord] = {}
+        self.symbols: Dict[int, SymbolRecord] = {}
+        self.threads: Dict[int, ThreadRecord] = {}
+
+        # Sequence counter for ordering
+        self.seq_counter = 0
+
+        # Metadata
+        self.metadata: Dict[str, Any] = {}
+
+        # For replay mode
+        self.replay_memory: Optional[SparseMemory] = None
+
+    def start_recording(self, prog: drgn.Program, output_path: str) -> None:
+        """
+        Start recording memory accesses to the specified output file.
+
+        Installs a hook on prog.read() to capture all memory reads.
+        """
+        if self.is_recording:
+            raise RuntimeError("Recording already in progress")
+
+        if self.is_replay:
+            raise RuntimeError("Cannot record while in replay mode")
+
+        self.output_path = output_path
+        self.is_recording = True
+        self.seq_counter = 0
+
+        # Clear buffers
+        self.memory = SparseMemory()
+        self.objects = {}
+        self.symbols = {}
+        self.threads = {}
+
+        # Store metadata about the session
+        platform = prog.platform
+        self.metadata = {
+            'version': BUNDLE_VERSION,
+            'timestamp': datetime.now().isoformat(),
+            'platform': str(platform) if platform else 'unknown',
+            'arch': platform.arch.name if platform else 'unknown',
+            'flags': platform.flags.value if platform else 0,
+        }
+
+        # Install the memory read hook
+        self._install_read_hook(prog)
+
+    def stop_recording(self, prog: drgn.Program) -> str:
+        """
+        Stop recording and save the bundle to disk.
+
+        Returns the path to the saved bundle.
+        """
+        if not self.is_recording:
+            raise RuntimeError("No recording in progress")
+
+        # Uninstall the hook first
+        self._uninstall_read_hook(prog)
+
+        self.is_recording = False
+
+        # Save the bundle
+        output_path = self.output_path
+        if output_path is None:
+            raise RuntimeError("No output path set")
+
+        self.save_bundle(output_path)
+
+        return output_path
+
+    def _install_read_hook(self, prog: drgn.Program) -> None:
+        """
+        Install the memory read hook with fat read support.
+
+        Since drgn.Program.read is read-only (C extension), we use a different
+        approach: we store a reference to prog.read and wrap calls to it through
+        our helper methods. SDB commands should use trace_read() instead of
+        prog.read() directly when recording is active.
+
+        For automatic tracing, we rely on the snapshot command or explicit
+        capture calls.
+        """
+        self.original_read = prog.read
+        self._recording_prog = prog
+
+    def _uninstall_read_hook(self, prog: drgn.Program) -> None:
+        """Clear the read hook references."""
+        # prog argument kept for API consistency and future use
+        _ = prog  # Mark as intentionally unused
+        self.original_read = None
+        self._recording_prog = None
+
+    def trace_read(self,
+                   address: int,
+                   size: int,
+                   physical: bool = False) -> bytes:
+        """
+        Read memory and trace it. Use this instead of prog.read() when recording.
+
+        Performs a fat read (256-byte aligned) to capture surrounding memory.
+        """
+        if self.original_read is None:
+            raise RuntimeError("No recording in progress")
+
+        # Calculate fat read boundaries (256-byte aligned)
+        aligned_start = address & FAT_READ_MASK
+        aligned_end = (address + size + FAT_READ_ALIGNMENT - 1) & FAT_READ_MASK
+
+        try:
+            # Try fat read first
+            fat_data = self.original_read(aligned_start,
+                                          aligned_end - aligned_start, physical)
+            self._log_read(aligned_start, fat_data)
+
+            # Return only the requested portion
+            offset = address - aligned_start
+            return fat_data[offset:offset + size]
+
+        except drgn.FaultError:
+            # Fat read failed (hit invalid memory), fall back to exact read
+            data = self.original_read(address, size, physical)
+            self._log_read(address, data)
+            return data
+
+    # pylint: disable=too-many-branches
+    def capture_object(self, obj: drgn.Object, depth: int = 1) -> None:
+        """
+        Capture an object's memory into the trace.
+
+        This forces a read of the object's memory and optionally follows
+        pointers up to the specified depth.
+        """
+        if not self.is_recording or self.original_read is None:
+            return
+
+        try:
+            self._capture_object_impl(obj, depth)
+        except (drgn.FaultError, ValueError, TypeError, OverflowError):
+            pass  # Ignore errors during capture
+
+    def _capture_object_impl(self, obj: drgn.Object, depth: int) -> None:
+        """Implementation of object capture, separated for complexity."""
+        # Handle pointer values - dereference to capture pointed-to memory
+        if obj.type_.kind == TypeKind.POINTER:
+            self._capture_pointer(obj, depth)
+            return
+
+        # For non-pointers, try to get the object's address
+        try:
+            addr = int(obj.address_of_())
+        except (ValueError, TypeError):
+            # Object is a value, not a reference - nothing to capture
+            return
+
+        size = obj.type_.size
+        if size is None or size == 0:
+            return
+
+        # Read and trace the memory
+        self.trace_read(addr, size)
+
+        # Record the object if it has a meaningful type
+        type_name = str(obj.type_)
+        if type_name and addr:
+            self.record_object(f"obj_{hex(addr)}", addr, type_name)
+
+        # For structs, optionally capture pointer members
+        if depth > 0 and obj.type_.kind == TypeKind.STRUCT:
+            self._capture_struct_pointers(obj, depth)
+
+    def _capture_pointer(self, obj: drgn.Object, depth: int) -> None:
+        """Capture memory pointed to by a pointer object."""
+        try:
+            ptr_value = int(obj)
+            if ptr_value == 0:  # Skip null pointers
+                return
+
+            # Get the pointed-to type's size
+            pointed_type = obj.type_.type
+            try:
+                type_size = pointed_type.size
+                size = min(type_size, 4096) if type_size else 256
+            except AttributeError:
+                size = 256  # Default for void or incomplete types
+
+            self.trace_read(ptr_value, size)
+
+            # Record this object
+            type_name = str(obj.type_)
+            self.record_object(f"ptr_{hex(ptr_value)}", ptr_value, type_name)
+
+            # Recursively capture the pointed-to object if depth > 0
+            if depth > 0:
+                try:
+                    pointed = obj[0]
+                    self.capture_object(pointed, depth - 1)
+                except drgn.FaultError:
+                    pass
+        except (ValueError, OverflowError):
+            pass
+
+    def _capture_struct_pointers(self, obj: drgn.Object, depth: int) -> None:
+        """Capture pointer members of a struct."""
+        for member in obj.type_.members:
+            if member.name:
+                try:
+                    member_obj = obj.member_(member.name)
+                    if member_obj.type_.kind == TypeKind.POINTER:
+                        self.capture_object(member_obj, depth - 1)
+                except (drgn.FaultError, ValueError, TypeError):
+                    pass
+
+    def _log_read(self, address: int, data: bytes) -> None:
+        """Log a memory read to the trace buffer."""
+        self.memory.write(address, data)
+        self.seq_counter += 1
+
+    def record_object(self, name: str, address: int, type_name: str) -> None:
+        """Record an object's name, address, and type."""
+        self.objects[name] = ObjectRecord(name=name,
+                                          address=address,
+                                          type_name=type_name)
+
+    def record_symbol(self, address: int, name: str, size: int = 0) -> None:
+        """Record a symbol at the given address."""
+        self.symbols[address] = SymbolRecord(name=name,
+                                             address=address,
+                                             size=size)
+
+    def record_thread_stack(self, tid: int, pcs: List[int]) -> None:
+        """Record a thread's stack trace as a list of program counters."""
+        self.threads[tid] = ThreadRecord(tid=tid, pcs=pcs)
+
+    def save_bundle(self, path: str) -> None:
+        """Save the recorded session to a .sdb bundle file."""
+        # Ensure .sdb extension
+        if not path.endswith('.sdb'):
+            path = path + '.sdb'
+
+        with zipfile.ZipFile(path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            # Write metadata
+            zf.writestr('metadata.json',
+                        json.dumps(self.metadata, indent=2).encode('utf-8'))
+
+            # Write objects
+            objects_data = {
+                name: {
+                    'address': rec.address,
+                    'type_name': rec.type_name
+                } for name, rec in self.objects.items()
+            }
+            zf.writestr('objects.json',
+                        json.dumps(objects_data, indent=2).encode('utf-8'))
+
+            # Write symbols (convert int keys to strings for JSON)
+            symbols_data = {
+                str(addr): {
+                    'name': rec.name,
+                    'size': rec.size
+                } for addr, rec in self.symbols.items()
+            }
+            zf.writestr('symbols.json',
+                        json.dumps(symbols_data, indent=2).encode('utf-8'))
+
+            # Write threads
+            threads_data = {
+                str(tid): {
+                    'pcs': rec.pcs
+                } for tid, rec in self.threads.items()
+            }
+            zf.writestr('threads.json',
+                        json.dumps(threads_data, indent=2).encode('utf-8'))
+
+            # Write memory as gzip-compressed binary
+            memory_bytes = self._serialize_memory()
+            compressed = gzip.compress(memory_bytes)
+            zf.writestr('memory.bin.gz', compressed)
+
+    def _serialize_memory(self) -> bytes:
+        """Serialize memory segments to binary format."""
+        parts = []
+
+        # Header: MAGIC (4 bytes) + VERSION (4 bytes, little-endian)
+        parts.append(MEMORY_MAGIC)
+        parts.append(struct.pack('<I', MEMORY_VERSION))
+
+        # Records: FLAGS (1 byte) + ADDRESS (8 bytes) + SIZE (4 bytes) + DATA
+        for start, _end, data in self.memory.segments:
+            flags = 0x01  # READ flag
+            size = len(data)
+            parts.append(struct.pack('<BQI', flags, start, size))
+            parts.append(data)
+
+        return b''.join(parts)
+
+    @classmethod
+    def load_bundle(cls, path: str) -> 'TraceManager':  # pylint: disable=too-many-locals
+        """Load a recorded session from a .sdb bundle file."""
+        manager = cls()
+        manager.is_replay = True
+
+        with zipfile.ZipFile(path, 'r') as zf:
+            # Load metadata
+            manager.metadata = json.loads(
+                zf.read('metadata.json').decode('utf-8'))
+
+            # Load objects
+            objects_data = json.loads(zf.read('objects.json').decode('utf-8'))
+            for name, obj in objects_data.items():
+                manager.objects[name] = ObjectRecord(name=name,
+                                                     address=obj['address'],
+                                                     type_name=obj['type_name'])
+
+            # Load symbols
+            symbols_data = json.loads(zf.read('symbols.json').decode('utf-8'))
+            for addr_str, sym in symbols_data.items():
+                addr = int(addr_str)
+                manager.symbols[addr] = SymbolRecord(name=sym['name'],
+                                                     address=addr,
+                                                     size=sym.get('size', 0))
+
+            # Load threads
+            threads_data = json.loads(zf.read('threads.json').decode('utf-8'))
+            for tid_str, thread in threads_data.items():
+                tid = int(tid_str)
+                manager.threads[tid] = ThreadRecord(tid=tid, pcs=thread['pcs'])
+
+            # Load memory
+            compressed = zf.read('memory.bin.gz')
+            memory_bytes = gzip.decompress(compressed)
+            manager._deserialize_memory(memory_bytes)
+
+        return manager
+
+    def _deserialize_memory(self, data: bytes) -> None:
+        """Deserialize memory from binary format."""
+        self.memory = SparseMemory()
+
+        if len(data) < 8:
+            raise ValueError("Invalid memory file: too short")
+
+        # Parse header
+        magic = data[:4]
+        if magic != MEMORY_MAGIC:
+            raise ValueError(f"Invalid memory file: bad magic {magic!r}")
+
+        version = struct.unpack('<I', data[4:8])[0]
+        if version != MEMORY_VERSION:
+            raise ValueError(f"Unsupported memory version: {version}")
+
+        # Parse records
+        offset = 8
+        while offset < len(data):
+            if offset + 13 > len(data):
+                break  # Not enough data for header
+
+            _flags, address, size = struct.unpack('<BQI',
+                                                  data[offset:offset + 13])
+            offset += 13
+
+            if offset + size > len(data):
+                raise ValueError("Invalid memory file: truncated record")
+
+            record_data = data[offset:offset + size]
+            offset += size
+
+            self.memory.write(address, record_data)
+
+    def setup_replay_program(self, prog: drgn.Program) -> None:
+        """
+        Set up a drgn.Program for replay mode.
+
+        Registers memory segments and finders from the loaded bundle.
+        """
+        if not self.is_replay:
+            raise RuntimeError("Not in replay mode")
+
+        # Create a memory reader callback
+        def memory_reader(address: int, count: int, _offset: int,
+                          _physical: bool) -> bytes:
+            return self.memory.read(address, count)
+
+        # Register the memory segment for the full address space
+        # We use a very large range to cover kernel addresses
+        prog.add_memory_segment(0, 0xFFFFFFFFFFFFFFFF, memory_reader)
+
+    def get_status(self) -> Dict[str, Any]:
+        """Get current session status."""
+        return {
+            'is_recording': self.is_recording,
+            'is_replay': self.is_replay,
+            'output_path': self.output_path,
+            'memory_segments': self.memory.get_segment_count(),
+            'memory_size': self.memory.get_total_size(),
+            'objects_count': len(self.objects),
+            'symbols_count': len(self.symbols),
+            'threads_count': len(self.threads),
+        }
+
+
+# Global trace manager instance
+_trace_manager: Optional[TraceManager] = None
+
+
+def get_trace_manager() -> TraceManager:
+    """Get or create the global trace manager."""
+    global _trace_manager  # pylint: disable=global-statement
+    if _trace_manager is None:
+        _trace_manager = TraceManager()
+    return _trace_manager
+
+
+def reset_trace_manager() -> None:
+    """Reset the global trace manager (for testing)."""
+    global _trace_manager  # pylint: disable=global-statement
+    _trace_manager = None

--- a/tests/integration/test_session_tracing.py
+++ b/tests/integration/test_session_tracing.py
@@ -1,0 +1,330 @@
+#
+# Copyright 2025 CoreWeave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Integration tests for session recording and replay functionality.
+
+These tests verify that:
+1. Session recording captures memory correctly from crash dumps
+2. The .sdb bundle format is correct
+3. Sessions can be loaded back
+4. The %session REPL commands work
+"""
+
+import json
+import os
+import tempfile
+from typing import Generator
+import zipfile
+
+import pytest
+
+import sdb
+from sdb.session import (
+    TraceManager,
+    get_trace_manager,
+    reset_trace_manager,
+)
+from tests.integration.infra import (
+    get_crash_dump_dir_paths,
+    get_all_reference_crash_dumps,
+    RefDump,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_trace_manager_fixture() -> Generator[None, None, None]:
+    """Reset the trace manager before and after each test."""
+    reset_trace_manager()
+    yield
+    reset_trace_manager()
+
+
+def setup_test_env(rdump: RefDump) -> None:
+    """Set up SDB environment for session tracing tests."""
+    sdb.target.set_prog(rdump.program)
+    sdb.register_commands()
+
+
+@pytest.mark.skipif(
+    len(get_crash_dump_dir_paths()) == 0,
+    reason="couldn't find any crash/core dumps to run tests against")
+class TestSessionRecording:
+    """Tests for session recording functionality."""
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_recording_captures_memory(self, rdump: RefDump) -> None:
+        """Test that recording a session captures memory."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+            assert trace_mgr.is_recording
+
+            # Run a command that accesses memory via repl_invoke (sets up target)
+            rdump.repl_invoke("addr init_task | head 1")
+
+            # Stop recording
+            saved_path = trace_mgr.stop_recording(rdump.program)
+            assert not trace_mgr.is_recording
+            assert os.path.exists(saved_path)
+
+            # Verify memory was captured
+            status = trace_mgr.get_status()
+            assert status['memory_size'] > 0
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_bundle_format(self, rdump: RefDump) -> None:
+        """Test that the bundle has the correct format."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Record something
+            trace_mgr.start_recording(rdump.program, bundle_path)
+            rdump.repl_invoke("addr init_task | head 1")
+            saved_path = trace_mgr.stop_recording(rdump.program)
+
+            # Verify bundle structure
+            with zipfile.ZipFile(saved_path, 'r') as zf:
+                names = zf.namelist()
+                assert 'metadata.json' in names
+                assert 'memory.bin.gz' in names
+                assert 'objects.json' in names
+                assert 'symbols.json' in names
+                assert 'threads.json' in names
+
+                # Verify metadata
+                metadata = json.loads(zf.read('metadata.json').decode('utf-8'))
+                assert 'version' in metadata
+                assert 'timestamp' in metadata
+                assert 'arch' in metadata
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_bundle_load_roundtrip(self, rdump: RefDump) -> None:
+        """Test that bundles can be saved and loaded."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Record something
+            trace_mgr.start_recording(rdump.program, bundle_path)
+            rdump.repl_invoke("addr init_task | head 1")
+            saved_path = trace_mgr.stop_recording(rdump.program)
+
+            original_size = trace_mgr.memory.get_total_size()
+            original_segments = trace_mgr.memory.get_segment_count()
+
+            # Load the bundle
+            loaded_mgr = TraceManager.load_bundle(saved_path)
+
+            # Verify data matches
+            assert loaded_mgr.is_replay
+            assert loaded_mgr.memory.get_total_size() == original_size
+            assert loaded_mgr.memory.get_segment_count() == original_segments
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_snapshot_command(self, rdump: RefDump) -> None:
+        """Test the %session snapshot command."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Use snapshot command (repl.eval_cmd handles % commands)
+            result = rdump.repl.eval_cmd("%session snapshot init_task")
+            assert result == 0
+
+            # Verify memory was captured
+            assert trace_mgr.memory.get_total_size() > 0
+
+            # Stop recording
+            trace_mgr.stop_recording(rdump.program)
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_status_command(self, rdump: RefDump) -> None:
+        """Test the %session status command."""
+        setup_test_env(rdump)
+
+        # Status without recording
+        result = rdump.repl.eval_cmd("%session status")
+        assert result == 0
+
+        # Status with recording
+        trace_mgr = get_trace_manager()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            result = rdump.repl.eval_cmd("%session status")
+            assert result == 0
+
+            trace_mgr.stop_recording(rdump.program)
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_record_stop_commands(self, rdump: RefDump) -> None:
+        """Test the %session record and stop commands."""
+        setup_test_env(rdump)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording via command
+            result = rdump.repl.eval_cmd(f"%session record {bundle_path}")
+            assert result == 0
+
+            trace_mgr = get_trace_manager()
+            assert trace_mgr.is_recording
+
+            # Run a command
+            rdump.repl_invoke("addr init_task | head 1")
+
+            # Stop recording via command
+            result = rdump.repl.eval_cmd("%session stop")
+            assert result == 0
+            assert not trace_mgr.is_recording
+
+            # Verify file was created (save_bundle adds .sdb if missing)
+            expected_path = bundle_path if bundle_path.endswith(
+                '.sdb') else bundle_path + '.sdb'
+            assert os.path.exists(expected_path)
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_fat_read_captures_surrounding_memory(self, rdump: RefDump) -> None:
+        """Test that fat reads capture 256-byte aligned memory."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Capture a pointer object - this should trigger fat reads
+            rdump.repl_invoke("addr init_task | head 1")
+
+            trace_mgr.stop_recording(rdump.program)
+
+            # Memory size should be aligned to 256 bytes
+            # (or larger due to multiple fat reads)
+            mem_size = trace_mgr.memory.get_total_size()
+            assert mem_size >= 256
+            # Memory should be captured in 256-byte aligned chunks
+            for start, _, _ in trace_mgr.memory.segments:
+                assert start % 256 == 0 or mem_size < 256
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_multiple_commands_accumulate(self, rdump: RefDump) -> None:
+        """Test that multiple commands accumulate memory in the trace."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Run first command
+            rdump.repl_invoke("addr init_task | head 1")
+            size_after_first = trace_mgr.memory.get_total_size()
+
+            # Run second command for different data
+            rdump.repl_invoke("addr jiffies | head 1")
+            size_after_second = trace_mgr.memory.get_total_size()
+
+            # Memory should have grown (or stayed same if overlapping)
+            assert size_after_second >= size_after_first
+
+            trace_mgr.stop_recording(rdump.program)
+
+
+@pytest.mark.skipif(
+    len(get_crash_dump_dir_paths()) == 0,
+    reason="couldn't find any crash/core dumps to run tests against")
+class TestSessionErrors:
+    """Tests for session error handling."""
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_stop_without_recording(self, rdump: RefDump) -> None:
+        """Test that stopping without recording gives an error."""
+        setup_test_env(rdump)
+
+        result = rdump.repl.eval_cmd("%session stop")
+        assert result == 1  # Error
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_double_start_recording(self, rdump: RefDump) -> None:
+        """Test that starting recording twice gives an error."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # First start should succeed
+            result = rdump.repl.eval_cmd(f"%session record {bundle_path}")
+            assert result == 0
+
+            # Second start should fail
+            result = rdump.repl.eval_cmd(f"%session record {bundle_path}2")
+            assert result == 1  # Error
+
+            # Clean up
+            trace_mgr.stop_recording(rdump.program)
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_snapshot_without_recording(self, rdump: RefDump) -> None:
+        """Test that snapshot without recording gives an error."""
+        setup_test_env(rdump)
+
+        result = rdump.repl.eval_cmd("%session snapshot init_task")
+        assert result == 1  # Error
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_unknown_session_command(self, rdump: RefDump) -> None:
+        """Test that unknown session commands give an error."""
+        setup_test_env(rdump)
+
+        result = rdump.repl.eval_cmd("%session bogus_command")
+        assert result == 1  # Error
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_unknown_meta_command(self, rdump: RefDump) -> None:
+        """Test that unknown % commands give an error."""
+        setup_test_env(rdump)
+
+        result = rdump.repl.eval_cmd("%bogus")
+        assert result == 1  # Error

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,383 @@
+#
+# Copyright 2025 CoreWeave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Unit tests for the session recording and replay functionality.
+"""
+
+import os
+import struct
+import tempfile
+import zipfile
+
+import pytest
+
+import drgn
+
+from sdb.session import (
+    SparseMemory,
+    TraceManager,
+    MemoryRecord,
+    ObjectRecord,
+    SymbolRecord,
+    ThreadRecord,
+    MEMORY_MAGIC,
+    MEMORY_VERSION,
+    FAT_READ_ALIGNMENT,
+    FAT_READ_MASK,
+    get_trace_manager,
+    reset_trace_manager,
+)
+
+
+class TestSparseMemory:
+    """Tests for the SparseMemory class."""
+
+    def test_write_and_read_simple(self) -> None:
+        """Test basic write and read operations."""
+        mem = SparseMemory()
+        data = b'hello world'
+        mem.write(0x1000, data)
+
+        result = mem.read(0x1000, len(data))
+        assert result == data
+
+    def test_write_and_read_partial(self) -> None:
+        """Test reading a partial segment."""
+        mem = SparseMemory()
+        data = b'0123456789'
+        mem.write(0x1000, data)
+
+        # Read middle portion
+        result = mem.read(0x1003, 4)
+        assert result == b'3456'
+
+    def test_multiple_disjoint_segments(self) -> None:
+        """Test multiple non-overlapping segments."""
+        mem = SparseMemory()
+        mem.write(0x1000, b'aaaa')
+        mem.write(0x2000, b'bbbb')
+        mem.write(0x3000, b'cccc')
+
+        assert mem.read(0x1000, 4) == b'aaaa'
+        assert mem.read(0x2000, 4) == b'bbbb'
+        assert mem.read(0x3000, 4) == b'cccc'
+
+    def test_overlapping_write_last_wins(self) -> None:
+        """Test that overlapping writes use last-write-wins semantics."""
+        mem = SparseMemory()
+        mem.write(0x1000, b'aaaaaaaaaa')  # 10 bytes
+        mem.write(0x1003, b'BBBB')  # Overlap in the middle
+
+        result = mem.read(0x1000, 10)
+        assert result == b'aaaBBBBaaa'
+
+    def test_overlapping_write_complete_cover(self) -> None:
+        """Test that a larger write completely covers a smaller one."""
+        mem = SparseMemory()
+        mem.write(0x1002, b'xx')
+        mem.write(0x1000, b'AAAAAAAA')  # Completely covers the first write
+
+        result = mem.read(0x1000, 8)
+        assert result == b'AAAAAAAA'
+
+    def test_read_missing_raises_fault(self) -> None:
+        """Test that reading missing memory raises an error."""
+        mem = SparseMemory()
+        mem.write(0x1000, b'aaaa')
+
+        with pytest.raises(drgn.FaultError):
+            mem.read(0x2000, 4)
+
+    def test_read_partial_missing_raises_fault(self) -> None:
+        """Test that reading partially missing memory raises an error."""
+        mem = SparseMemory()
+        mem.write(0x1000, b'aaaa')
+
+        # Try to read beyond the segment
+        with pytest.raises(drgn.FaultError):
+            mem.read(0x1002, 8)  # Only 2 bytes available, requesting 8
+
+    def test_adjacent_segments(self) -> None:
+        """Test reading across adjacent segments."""
+        mem = SparseMemory()
+        mem.write(0x1000, b'aaaa')
+        mem.write(0x1004, b'bbbb')
+
+        result = mem.read(0x1000, 8)
+        assert result == b'aaaabbbb'
+
+    def test_get_total_size(self) -> None:
+        """Test total size calculation."""
+        mem = SparseMemory()
+        mem.write(0x1000, b'aaaa')
+        mem.write(0x2000, b'bbbbbb')
+
+        assert mem.get_total_size() == 10
+
+    def test_get_segment_count(self) -> None:
+        """Test segment count."""
+        mem = SparseMemory()
+        assert mem.get_segment_count() == 0
+
+        mem.write(0x1000, b'aaaa')
+        assert mem.get_segment_count() == 1
+
+        mem.write(0x2000, b'bbbb')
+        assert mem.get_segment_count() == 2
+
+    def test_empty_write_ignored(self) -> None:
+        """Test that empty writes are ignored."""
+        mem = SparseMemory()
+        mem.write(0x1000, b'')
+        assert mem.get_segment_count() == 0
+
+    def test_empty_read_returns_empty(self) -> None:
+        """Test that reading 0 bytes returns empty."""
+        mem = SparseMemory()
+        result = mem.read(0x1000, 0)
+        assert result == b''
+
+
+class TestTraceManager:
+    """Tests for the TraceManager class."""
+
+    def setup_method(self) -> None:
+        """Reset trace manager before each test."""
+        reset_trace_manager()
+
+    def test_initial_state(self) -> None:
+        """Test initial state of TraceManager."""
+        mgr = TraceManager()
+        assert not mgr.is_recording
+        assert not mgr.is_replay
+        assert mgr.output_path is None
+
+    def test_record_object(self) -> None:
+        """Test recording an object."""
+        mgr = TraceManager()
+        mgr.record_object('my_var', 0x1234, 'struct foo')
+
+        assert 'my_var' in mgr.objects
+        assert mgr.objects['my_var'].address == 0x1234
+        assert mgr.objects['my_var'].type_name == 'struct foo'
+
+    def test_record_symbol(self) -> None:
+        """Test recording a symbol."""
+        mgr = TraceManager()
+        mgr.record_symbol(0xffff0000, 'my_function', 100)
+
+        assert 0xffff0000 in mgr.symbols
+        assert mgr.symbols[0xffff0000].name == 'my_function'
+        assert mgr.symbols[0xffff0000].size == 100
+
+    def test_record_thread_stack(self) -> None:
+        """Test recording thread stack."""
+        mgr = TraceManager()
+        pcs = [0x1000, 0x2000, 0x3000]
+        mgr.record_thread_stack(1234, pcs)
+
+        assert 1234 in mgr.threads
+        assert mgr.threads[1234].pcs == pcs
+
+    def test_get_status(self) -> None:
+        """Test status reporting."""
+        mgr = TraceManager()
+        mgr.memory.write(0x1000, b'test data')
+        mgr.record_object('var1', 0x1000, 'int')
+        mgr.record_symbol(0x2000, 'func', 50)
+
+        status = mgr.get_status()
+        assert status['is_recording'] is False
+        assert status['is_replay'] is False
+        assert status['memory_size'] == 9
+        assert status['objects_count'] == 1
+        assert status['symbols_count'] == 1
+
+
+class TestBundleIO:
+    """Tests for bundle save/load functionality."""
+
+    def test_save_and_load_bundle(self) -> None:
+        """Test saving and loading a bundle."""
+        mgr = TraceManager()
+
+        # Add some test data
+        mgr.memory.write(0x1000, b'memory content here')
+        mgr.record_object('test_var', 0x1000, 'struct test')
+        mgr.record_symbol(0xffff0000, 'test_func', 200)
+        mgr.record_thread_stack(42, [0x1000, 0x2000, 0x3000])
+        mgr.metadata = {
+            'version': 1,
+            'timestamp': '2025-01-01T00:00:00',
+            'platform': 'test',
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, 'test.sdb')
+            mgr.save_bundle(bundle_path)
+
+            # Verify the bundle exists and is a valid ZIP
+            assert os.path.exists(bundle_path)
+            with zipfile.ZipFile(bundle_path, 'r') as zf:
+                assert 'metadata.json' in zf.namelist()
+                assert 'objects.json' in zf.namelist()
+                assert 'symbols.json' in zf.namelist()
+                assert 'threads.json' in zf.namelist()
+                assert 'memory.bin.gz' in zf.namelist()
+
+            # Load and verify
+            loaded = TraceManager.load_bundle(bundle_path)
+            assert loaded.is_replay is True
+
+            # Verify memory
+            assert loaded.memory.read(0x1000, 19) == b'memory content here'
+
+            # Verify objects
+            assert 'test_var' in loaded.objects
+            assert loaded.objects['test_var'].address == 0x1000
+            assert loaded.objects['test_var'].type_name == 'struct test'
+
+            # Verify symbols
+            assert 0xffff0000 in loaded.symbols
+            assert loaded.symbols[0xffff0000].name == 'test_func'
+
+            # Verify threads
+            assert 42 in loaded.threads
+            assert loaded.threads[42].pcs == [0x1000, 0x2000, 0x3000]
+
+    def test_bundle_adds_sdb_extension(self) -> None:
+        """Test that .sdb extension is added if missing."""
+        mgr = TraceManager()
+        mgr.memory.write(0x1000, b'test')
+        mgr.metadata = {'version': 1}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, 'test')
+            mgr.save_bundle(bundle_path)
+
+            assert os.path.exists(bundle_path + '.sdb')
+
+    def test_memory_binary_format(self) -> None:
+        """Test the binary memory format directly."""
+        mgr = TraceManager()
+        mgr.memory.write(0x1000, b'aaaa')
+        mgr.memory.write(0x2000, b'bbbb')
+
+        # pylint: disable=protected-access
+        data = mgr._serialize_memory()
+
+        # Verify header
+        assert data[:4] == MEMORY_MAGIC
+        version = struct.unpack('<I', data[4:8])[0]
+        assert version == MEMORY_VERSION
+
+        # Parse records
+        offset = 8
+        records = []
+        while offset < len(data):
+            _flags, address, size = struct.unpack('<BQI',
+                                                  data[offset:offset + 13])
+            offset += 13
+            record_data = data[offset:offset + size]
+            offset += size
+            records.append((address, record_data))
+
+        # Should have 2 records
+        assert len(records) == 2
+        addresses = {r[0] for r in records}
+        assert 0x1000 in addresses
+        assert 0x2000 in addresses
+
+
+class TestFatReadAlignment:
+    """Tests for fat read alignment."""
+
+    def test_fat_read_alignment_constant(self) -> None:
+        """Test that fat read alignment is 256 bytes as designed."""
+        assert FAT_READ_ALIGNMENT == 256
+
+    def test_alignment_mask(self) -> None:
+        """Test alignment calculation."""
+        # Test various addresses
+        test_cases = [
+            (0x1000, 0x1000),  # Already aligned
+            (0x1001, 0x1000),  # Just after boundary
+            (0x10FF, 0x1000),  # Just before next boundary
+            (0x1100, 0x1100),  # Next boundary
+            (0x1234, 0x1200),  # Random address
+        ]
+
+        for addr, expected_aligned in test_cases:
+            aligned = addr & FAT_READ_MASK
+            assert aligned == expected_aligned, \
+                f"0x{addr:x} -> 0x{aligned:x}, expected 0x{expected_aligned:x}"
+
+
+class TestGlobalTraceManager:
+    """Tests for global trace manager singleton."""
+
+    def setup_method(self) -> None:
+        """Reset trace manager before each test."""
+        reset_trace_manager()
+
+    def test_get_trace_manager_singleton(self) -> None:
+        """Test that get_trace_manager returns the same instance."""
+        mgr1 = get_trace_manager()
+        mgr2 = get_trace_manager()
+        assert mgr1 is mgr2
+
+    def test_reset_trace_manager(self) -> None:
+        """Test that reset creates a new instance."""
+        mgr1 = get_trace_manager()
+        reset_trace_manager()
+        mgr2 = get_trace_manager()
+        assert mgr1 is not mgr2
+
+
+class TestDataclasses:
+    """Tests for dataclass records."""
+
+    def test_memory_record(self) -> None:
+        """Test MemoryRecord dataclass."""
+        rec = MemoryRecord(address=0x1000, data=b'test', seq_id=5)
+        assert rec.address == 0x1000
+        assert rec.data == b'test'
+        assert rec.seq_id == 5
+
+    def test_object_record(self) -> None:
+        """Test ObjectRecord dataclass."""
+        rec = ObjectRecord(name='var', address=0x2000, type_name='int')
+        assert rec.name == 'var'
+        assert rec.address == 0x2000
+        assert rec.type_name == 'int'
+
+    def test_symbol_record(self) -> None:
+        """Test SymbolRecord dataclass."""
+        rec = SymbolRecord(name='func', address=0x3000, size=100)
+        assert rec.name == 'func'
+        assert rec.address == 0x3000
+        assert rec.size == 100
+
+    def test_thread_record(self) -> None:
+        """Test ThreadRecord dataclass."""
+        rec = ThreadRecord(tid=42, pcs=[0x1000, 0x2000])
+        assert rec.tid == 42
+        assert rec.pcs == [0x1000, 0x2000]
+
+    def test_thread_record_default_pcs(self) -> None:
+        """Test ThreadRecord default pcs."""
+        rec = ThreadRecord(tid=1)
+        assert rec.pcs == []


### PR DESCRIPTION
Implement a comprehensive session recording system that captures memory accesses during live debugging sessions and allows offline replay. This enables use cases like:
- Remote debugging without sharing full crash dumps
- Creating "filtered" dumps with only accessed memory
- Regression testing of SDB commands
- Collaboration where person A records and person B analyzes

=== New Files ===

sdb/session.py:
  Core session recording/replay infrastructure including:
  - SparseMemory: Non-contiguous memory storage with LWW overlap resolution
  - TraceManager: Central coordinator for recording state and bundle I/O
  - Record dataclasses: MemoryRecord, ObjectRecord, SymbolRecord, ThreadRecord
  - Binary memory format: Compact storage with gzip compression
  - Bundle format: ZIP archive (.sdb) containing metadata.json, memory.bin.gz, objects.json, symbols.json, threads.json

tests/unit/test_session.py:
  Unit tests for SparseMemory, TraceManager, bundle I/O, fat read alignment,
  global trace manager singleton, and dataclass records. (29 tests)

tests/integration/test_session_tracing.py:
  Integration tests using crash dumps to verify end-to-end recording and
  replay functionality. Tests recording, bundle format, load/save roundtrip,
  %session commands, fat reads, and error handling. (26 tests)

=== Modified Files ===

sdb/internal/repl.py:
  - Add support for % meta-commands in the REPL
  - Implement eval_session_cmd() to handle:
    - %session record <file.sdb> - Start recording
    - %session stop - Stop recording and save bundle
    - %session status - Show recording status
    - %session snapshot <var> [--depth N] - Capture object graph
    - %session load <file.sdb> - Load recorded session

sdb/internal/cli.py:
  - Add --record <file> CLI argument for automatic recording on startup
  - Add --replay <file> CLI argument for offline replay mode
  - Integrate TraceManager lifecycle with main() function
  - Implement setup_replay_target() for replay program initialization

=== Key Design Decisions ===

1. Memory Capture: Uses 256-byte aligned "fat reads" to capture surrounding context, increasing the chance that replay has data person B needs even if person A didn't explicitly access it.

2. Overlap Resolution: Last-Write-Wins (LWW) flattening at load time for overlapping memory regions, ensuring consistent memory view during replay.

3. Platform Info: Captures drgn.Platform details (address size, flags) during recording and restores during replay for correct memory operations.

4. Compression: Uses gzip (stdlib) for memory data compression, keeping the implementation dependency-free.

5. Bundle Format: ZIP-based .sdb bundles for easy inspection and manipulation.

=== Usage Examples ===

CLI recording:
  $ sdb --record session.sdb /path/to/vmcore

CLI replay:
  $ sdb --replay session.sdb

Interactive recording:
  sdb> %session record mysession.sdb
  sdb> spa | head 1 | print
  sdb> %session snapshot arc_stats
  sdb> %session stop

=== TODO: Future Enhancements ===

- Alternative compression algorithms (zstd, lz4) for better ratios/speed
- BTF support for type storage (currently relies on original DWARF)
- Type information embedding for DWARF-independent replay
- Memory segment deduplication for repeated reads
- Incremental recording/append mode
- Session comparison/diffing tools
- Statistics/profiling for captured memory patterns
- Export to other formats (e.g., minidump)
- Configurable fat read alignment
- Thread stack trace recording via prog.stack_trace_from_pcs()