### PR TITLE
session: Fix typedef type size resolution in capture_object

### DIFF
--- a/sdb/session.py
+++ b/sdb/session.py
@@ -399,8 +399,12 @@ class TraceManager:
             # Object is a value, not a reference - nothing to capture
             return
 
-        size = obj.type_.size
-        if size is None or size == 0:
+        # Use drgn.sizeof() which resolves typedefs to get the actual size
+        try:
+            size = drgn.sizeof(obj.type_)
+        except (TypeError, ValueError):
+            size = 0
+        if size == 0:
             return
 
         # Read and trace the memory


### PR DESCRIPTION
When capturing objects, the code accessed obj.type_.size directly which fails for typedef types with 'AttributeError: typedef type does not have a size'.

Instead of giving up on these types, use drgn.sizeof(obj.type_) which properly resolves typedefs to get the underlying type's actual size.

This allows capturing variables like zfs_dbgmsgs and spa_namespace_avl that are typedef'd list/avl structures.