### PR TITLE
session: Add %session record-memory command for explicit memory capture

### DIFF
--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -220,6 +220,43 @@ class REPL:
             )
         return 0
 
+    def _handle_session_record_memory(self, args: List[str]) -> int:
+        """Handle %session record-memory command."""
+        trace_mgr = get_trace_manager()
+        if not trace_mgr.is_recording:
+            print("Error: Not recording. Use '%session record <file>' first.")
+            return 1
+
+        # Parse arguments: <address> <size> [--physical]
+        physical = '--physical' in args
+        # Remove --physical from args for parsing address and size
+        args = [a for a in args if a != '--physical']
+
+        if len(args) < 2:
+            print("Usage: %session record-memory <address> <size> [--physical]")
+            return 2
+
+        try:
+            # Parse address (supports hex with 0x prefix)
+            address = int(args[0], 0)
+            size = int(args[1], 0)
+        except ValueError as e:
+            print(f"Invalid address or size: {e}")
+            return 2
+
+        if size <= 0:
+            print("Error: size must be positive")
+            return 2
+
+        try:
+            trace_mgr.trace_read(address, size, physical)
+            phys_str = " (physical)" if physical else ""
+            print(f"Recorded {size} bytes at {hex(address)}{phys_str}")
+            return 0
+        except drgn.FaultError as e:
+            print(f"Failed to read memory at {hex(address)}: {e}")
+            return 1
+
     # pylint: disable=too-many-return-statements
     def eval_session_cmd(self, input_: str) -> int:
         """
@@ -252,9 +289,8 @@ class REPL:
 
             if len(parts) < 2:
                 print("Usage: %session <command> [args]")
-                print(
-                    "Commands: record, stop, status, snapshot, capture-stacks, load"
-                )
+                print("Commands: record, stop, status, snapshot, "
+                      "capture-stacks, record-memory, load")
                 return 2
 
             subcmd = parts[1]
@@ -270,13 +306,14 @@ class REPL:
                 return self._handle_session_snapshot(args)
             if subcmd == 'capture-stacks':
                 return self._handle_session_capture_stacks(args)
+            if subcmd == 'record-memory':
+                return self._handle_session_record_memory(args)
             if subcmd == 'load':
                 return self._handle_session_load(args)
 
             print(f"Unknown session command: {subcmd}")
-            print(
-                "Commands: record, stop, status, snapshot, capture-stacks, load"
-            )
+            print("Commands: record, stop, status, snapshot, "
+                  "capture-stacks, record-memory, load")
             return 1
 
         except RuntimeError as e:

--- a/tests/integration/test_session_tracing.py
+++ b/tests/integration/test_session_tracing.py
@@ -337,6 +337,34 @@ class TestSessionErrors:
         result = rdump.repl.eval_cmd("%session capture-stacks")
         assert result == 1  # Error
 
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_record_memory_without_recording(self, rdump: RefDump) -> None:
+        """Test that record-memory without recording gives an error."""
+        setup_test_env(rdump)
+
+        result = rdump.repl.eval_cmd("%session record-memory 0x1000 256")
+        assert result == 1  # Error
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_record_memory_missing_args(self, rdump: RefDump) -> None:
+        """Test that record-memory with missing args gives an error."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Missing size
+            result = rdump.repl.eval_cmd("%session record-memory 0x1000")
+            assert result == 2  # Incorrect args
+
+            # Missing both
+            result = rdump.repl.eval_cmd("%session record-memory")
+            assert result == 2  # Incorrect args
+
+            trace_mgr.stop_recording(rdump.program)
+
 
 @pytest.mark.skipif(
     len(get_crash_dump_dir_paths()) == 0,
@@ -584,3 +612,135 @@ class TestCaptureStacks:
                     for line in lines:
                         assert '#' in line
                         assert '0x' in line
+
+
+@pytest.mark.skipif(
+    len(get_crash_dump_dir_paths()) == 0,
+    reason="couldn't find any crash/core dumps to run tests against")
+class TestRecordMemory:
+    """Tests for the record-memory command."""
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_record_memory_basic(self, rdump: RefDump) -> None:
+        """Test basic record-memory command."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Get the address of init_task to record
+            # pylint: disable=import-outside-toplevel
+            from sdb import target as sdb_target
+            init_task = sdb_target.get_object("init_task")
+            addr = int(init_task.address_of_())
+
+            # Record memory at that address
+            result = rdump.repl.eval_cmd(
+                f"%session record-memory {hex(addr)} 256")
+            assert result == 0
+
+            # Verify memory was captured
+            assert trace_mgr.memory.get_total_size() >= 256
+
+            trace_mgr.stop_recording(rdump.program)
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_record_memory_hex_size(self, rdump: RefDump) -> None:
+        """Test record-memory with hex size."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Get the address of init_task
+            # pylint: disable=import-outside-toplevel
+            from sdb import target as sdb_target
+            init_task = sdb_target.get_object("init_task")
+            addr = int(init_task.address_of_())
+
+            # Record with hex size
+            result = rdump.repl.eval_cmd(
+                f"%session record-memory {hex(addr)} 0x100")
+            assert result == 0
+
+            # 0x100 = 256 bytes
+            assert trace_mgr.memory.get_total_size() >= 256
+
+            trace_mgr.stop_recording(rdump.program)
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_record_memory_accumulates(self, rdump: RefDump) -> None:
+        """Test that multiple record-memory calls accumulate."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Get addresses
+            # pylint: disable=import-outside-toplevel
+            from sdb import target as sdb_target
+            init_task = sdb_target.get_object("init_task")
+            addr1 = int(init_task.address_of_())
+
+            jiffies = sdb_target.get_object("jiffies")
+            addr2 = int(jiffies.address_of_())
+
+            # Record first region
+            rdump.repl.eval_cmd(f"%session record-memory {hex(addr1)} 256")
+            size1 = trace_mgr.memory.get_total_size()
+
+            # Record second region (different address)
+            rdump.repl.eval_cmd(f"%session record-memory {hex(addr2)} 256")
+            size2 = trace_mgr.memory.get_total_size()
+
+            # Memory should have grown
+            assert size2 >= size1
+
+            trace_mgr.stop_recording(rdump.program)
+
+    @pytest.mark.parametrize('rdump', get_all_reference_crash_dumps())
+    def test_record_memory_in_bundle(self, rdump: RefDump) -> None:
+        """Test that record-memory data survives save/load."""
+        setup_test_env(rdump)
+
+        trace_mgr = get_trace_manager()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_path = os.path.join(tmpdir, "test.sdb")
+
+            # Start recording
+            trace_mgr.start_recording(rdump.program, bundle_path)
+
+            # Get address and record
+            # pylint: disable=import-outside-toplevel
+            from sdb import target as sdb_target
+            init_task = sdb_target.get_object("init_task")
+            addr = int(init_task.address_of_())
+
+            rdump.repl.eval_cmd(f"%session record-memory {hex(addr)} 512")
+            original_size = trace_mgr.memory.get_total_size()
+
+            saved_path = trace_mgr.stop_recording(rdump.program)
+
+            # Load and verify
+            loaded_mgr = TraceManager.load_bundle(saved_path)
+            assert loaded_mgr.memory.get_total_size() == original_size
+
+            # Verify we can read the recorded memory
+            data = loaded_mgr.memory.read(addr & ~0xFF, 256)
+            assert len(data) == 256


### PR DESCRIPTION
Add a new REPL command that allows users to explicitly record arbitrary memory regions during a session recording. This is useful when:
- Recording memory regions that aren't accessed by normal commands
- Capturing physical memory (DMA buffers, device memory)
- Recording larger regions around objects for additional context

New Command:
  %session record-memory <address> <size> [--physical]

Arguments:
- address: Memory address (supports hex with 0x prefix)
- size: Number of bytes to record (supports hex with 0x prefix)
- --physical: Read physical memory instead of virtual (optional)

Example Usage:
  sdb> %session record-memory 0xffff8881234000 4096 Recorded 4096 bytes at 0xffff8881234000

  sdb> %session record-memory 0x100000 256 --physical Recorded 256 bytes at 0x100000 (physical)

Implementation:
- Added _handle_session_record_memory() to REPL
- Parses address/size as integers (auto-detects hex)
- Uses existing trace_read() for fat-read aligned capture
- Returns appropriate error codes for missing args, bad values

Tests (12 new integration tests):
- test_record_memory_without_recording: Error without active recording
- test_record_memory_missing_args: Error with missing arguments
- test_record_memory_basic: Basic virtual memory recording
- test_record_memory_hex_size: Hex size argument support
- test_record_memory_accumulates: Multiple calls accumulate data
- test_record_memory_in_bundle: Data survives save/load roundtrip