### PR TITLE
ci: relax pylint rules and drop inline disables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,8 @@ jobs:
           python-version: '3.10'
       - run: ./.github/scripts/install-drgn.sh
       - run: python3 -m pip install pylint pytest
-      - run: pylint -d duplicate-code -d invalid-name sdb
-      - run: pylint -d duplicate-code -d invalid-name tests
+      - run: pylint -d duplicate-code -d invalid-name -d missing-docstring -d import-outside-toplevel -d too-many-branches -d missing-module-docstring -d missing-function-docstring sdb
+      - run: pylint -d duplicate-code -d invalid-name -d missing-docstring -d import-outside-toplevel -d too-many-branches -d missing-module-docstring -d missing-function-docstring tests
   #
   # Verify "pytest" runs successfully on unit tests.
   #

--- a/sdb/command.py
+++ b/sdb/command.py
@@ -97,7 +97,6 @@ def get_registered_commands() -> Dict[str, Type["Command"]]:
     return registered_commands
 
 
-# pylint: disable=too-many-branches
 def register_commands() -> None:
     """
     Iterate over the set of all commands and register the ones appropriate for the
@@ -250,7 +249,6 @@ class Command:
         command class that it's called on. The docstring and parser for
         the class is used to populate the contents of the message.
         """
-        # pylint: disable=too-many-branches
         parser = cls._init_parser(name)
 
         print("SUMMARY")
@@ -432,7 +430,6 @@ class Command:
             yield obj
 
     def call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
-        # pylint: disable=missing-docstring
         #
         # Even though we have __invalid_memory_objects_check() to
         # ensure that the objects returned are valid, we still
@@ -518,7 +515,6 @@ class Walker(Command):
         Walker.allWalkers[class_.input_type] = class_
 
     def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
-        # pylint: disable=missing-docstring
         raise NotImplementedError
 
     # Iterate over the inputs and call the walk command on each of them,
@@ -559,7 +555,6 @@ class PrettyPrinter(Command):
         PrettyPrinter.all_printers[class_.input_type] = class_
 
     def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
-        # pylint: disable=missing-docstring
         raise NotImplementedError
 
     def check_input_type(self,
@@ -603,7 +598,6 @@ class Locator(Command):
     output_type: Optional[str] = None
 
     def no_input(self) -> Iterable[drgn.Object]:
-        # pylint: disable=missing-docstring
         raise CommandError(self.name, "command requires an input")
 
     def caller(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
@@ -663,7 +657,6 @@ class Locator(Command):
 
     def _call(self,
               objs: Iterable[drgn.Object]) -> Optional[Iterable[drgn.Object]]:
-        # pylint: disable=missing-docstring
         # If this is a hybrid locator/pretty printer, this is where that is
         # leveraged.
         if self.islast and isinstance(self, PrettyPrinter):
@@ -816,7 +809,6 @@ class Address(Command):
 
     @staticmethod
     def is_hex(arg: str) -> bool:
-        # pylint: disable=missing-docstring
         try:
             int(arg, 16)
             return True
@@ -825,7 +817,6 @@ class Address(Command):
 
     @staticmethod
     def resolve_for_address(arg: str) -> drgn.Object:
-        # pylint: disable=missing-docstring
         if Address.is_hex(arg):
             return target.create_object("void *", int(arg, 16))
         return target.get_object(arg).address_of_()

--- a/sdb/commands/__init__.py
+++ b/sdb/commands/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import glob
 import importlib
 import os

--- a/sdb/commands/array.py
+++ b/sdb/commands/array.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/container_of.py
+++ b/sdb/commands/container_of.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
 
 #
 # The pylint workaround below is for the example

--- a/sdb/commands/count.py
+++ b/sdb/commands/count.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/echo.py
+++ b/sdb/commands/echo.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/exit.py
+++ b/sdb/commands/exit.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/filter.py
+++ b/sdb/commands/filter.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable, List, Optional
 

--- a/sdb/commands/head.py
+++ b/sdb/commands/head.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/help.py
+++ b/sdb/commands/help.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable, Dict, Type
 

--- a/sdb/commands/history.py
+++ b/sdb/commands/history.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import readline
 import argparse
 from typing import Iterable

--- a/sdb/commands/internal/__init__.py
+++ b/sdb/commands/internal/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import glob
 import importlib
 import os

--- a/sdb/commands/internal/table.py
+++ b/sdb/commands/internal/table.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 

--- a/sdb/commands/internal/util.py
+++ b/sdb/commands/internal/util.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import drgn
 import sdb
 

--- a/sdb/commands/linux/__init__.py
+++ b/sdb/commands/linux/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import glob
 import importlib
 import os

--- a/sdb/commands/linux/dmesg.py
+++ b/sdb/commands/linux/dmesg.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/linux/internal/__init__.py
+++ b/sdb/commands/linux/internal/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import glob
 import importlib
 import os

--- a/sdb/commands/linux/internal/slub_helpers.py
+++ b/sdb/commands/linux/internal/slub_helpers.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable, Optional, Tuple
 
 import drgn

--- a/sdb/commands/linux/linked_lists.py
+++ b/sdb/commands/linux/linked_lists.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
 
 #
 # The pylint workaround below is for the example

--- a/sdb/commands/linux/per_cpu.py
+++ b/sdb/commands/linux/per_cpu.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable, List, Optional
 

--- a/sdb/commands/linux/process.py
+++ b/sdb/commands/linux/process.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/linux/slabs.py
+++ b/sdb/commands/linux/slabs.py
@@ -19,7 +19,6 @@
 # added in slub_cache command.
 #
 # pylint: disable=line-too-long
-# pylint: disable=missing-docstring
 
 import argparse
 import textwrap

--- a/sdb/commands/linux/stacks.py
+++ b/sdb/commands/linux/stacks.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Dict, Iterable, List, Optional, Tuple
 from collections import defaultdict
@@ -425,7 +423,8 @@ class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
             stack_aggr[stack_key].append(task)
         return sorted(stack_aggr.items(), key=lambda x: len(x[1]), reverse=True)
 
-    # pylint: disable=too-many-branches,too-many-statements
+# pylint: disable=too-many-statements
+
     def _format_stack_from_pcs(self, pcs: List[int]) -> str:
         """
         Format a stack trace from recorded PCs using hybrid approach.
@@ -521,7 +520,9 @@ class KernelStacks(sdb.Locator, sdb.PrettyPrinter):
 
         return stacktrace_info
 
-    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+
+# pylint: disable=too-many-locals, too-many-statements
+
     def print_stacks(self, objs: Iterable[drgn.Object]) -> None:
         self.print_header()
         replay = is_replay_mode()

--- a/sdb/commands/linux/threads.py
+++ b/sdb/commands/linux/threads.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 import os
 from textwrap import shorten

--- a/sdb/commands/linux/tree.py
+++ b/sdb/commands/linux/tree.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/linux/vfs.py
+++ b/sdb/commands/linux/vfs.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/linux/whatis.py
+++ b/sdb/commands/linux/whatis.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/member.py
+++ b/sdb/commands/member.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from enum import Enum
 from typing import Iterable, List, Tuple

--- a/sdb/commands/pretty_print.py
+++ b/sdb/commands/pretty_print.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/print.py
+++ b/sdb/commands/print.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 
 import drgn

--- a/sdb/commands/ptype.py
+++ b/sdb/commands/ptype.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/pyfilter.py
+++ b/sdb/commands/pyfilter.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable, List, Optional
 

--- a/sdb/commands/sizeof.py
+++ b/sdb/commands/sizeof.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/spl/__init__.py
+++ b/sdb/commands/spl/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import glob
 import importlib
 import os

--- a/sdb/commands/spl/avl.py
+++ b/sdb/commands/spl/avl.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/spl/internal/__init__.py
+++ b/sdb/commands/spl/internal/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import glob
 import importlib
 import os

--- a/sdb/commands/spl/internal/kmem_helpers.py
+++ b/sdb/commands/spl/internal/kmem_helpers.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/spl/multilist.py
+++ b/sdb/commands/spl/multilist.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/spl/spl_kmem_caches.py
+++ b/sdb/commands/spl/spl_kmem_caches.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 import textwrap
 from typing import Any, Dict, Iterable, List, Tuple

--- a/sdb/commands/spl/spl_list.py
+++ b/sdb/commands/spl/spl_list.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/sum.py
+++ b/sdb/commands/sum.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/tail.py
+++ b/sdb/commands/tail.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from collections import deque
 from typing import Deque, Iterable

--- a/sdb/commands/type.py
+++ b/sdb/commands/type.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import drgn
 import sdb
 

--- a/sdb/commands/ustacks.py
+++ b/sdb/commands/ustacks.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Dict, Iterable, List, Optional, Tuple
 from collections import defaultdict

--- a/sdb/commands/uthreads.py
+++ b/sdb/commands/uthreads.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/zfs/__init__.py
+++ b/sdb/commands/zfs/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import glob
 import importlib
 import os

--- a/sdb/commands/zfs/arc.py
+++ b/sdb/commands/zfs/arc.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/zfs/blkptr.py
+++ b/sdb/commands/zfs/blkptr.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/zfs/btree.py
+++ b/sdb/commands/zfs/btree.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable, List, Optional
 
 import drgn

--- a/sdb/commands/zfs/dbuf.py
+++ b/sdb/commands/zfs/dbuf.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/zfs/histograms.py
+++ b/sdb/commands/zfs/histograms.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/zfs/internal/__init__.py
+++ b/sdb/commands/zfs/internal/__init__.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import drgn
 import sdb
 

--- a/sdb/commands/zfs/metaslab.py
+++ b/sdb/commands/zfs/metaslab.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable
 

--- a/sdb/commands/zfs/range_tree.py
+++ b/sdb/commands/zfs/range_tree.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Iterable
 
 import drgn

--- a/sdb/commands/zfs/spa.py
+++ b/sdb/commands/zfs/spa.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable, List, Optional
 

--- a/sdb/commands/zfs/vdev.py
+++ b/sdb/commands/zfs/vdev.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable, List, Optional
 

--- a/sdb/commands/zfs/zfs_dbgmsg.py
+++ b/sdb/commands/zfs/zfs_dbgmsg.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 import datetime
 from typing import Iterable

--- a/sdb/commands/zfs/zio.py
+++ b/sdb/commands/zfs/zio.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import argparse
 from typing import Iterable, List, Optional
 

--- a/sdb/error.py
+++ b/sdb/error.py
@@ -29,7 +29,6 @@ class Error(Exception):
 
 
 class CommandNotFoundError(Error):
-    # pylint: disable=missing-docstring
 
     command: str = ""
 
@@ -39,7 +38,6 @@ class CommandNotFoundError(Error):
 
 
 class CommandError(Error):
-    # pylint: disable=missing-docstring
 
     command: str = ""
     message: str = ""
@@ -51,7 +49,6 @@ class CommandError(Error):
 
 
 class CommandInvalidInputError(CommandError):
-    # pylint: disable=missing-docstring
 
     argument: str = ""
 
@@ -61,7 +58,6 @@ class CommandInvalidInputError(CommandError):
 
 
 class SymbolNotFoundError(CommandError):
-    # pylint: disable=missing-docstring
 
     symbol: str = ""
 
@@ -71,7 +67,6 @@ class SymbolNotFoundError(CommandError):
 
 
 class CommandArgumentsError(CommandError):
-    # pylint: disable=missing-docstring
 
     def __init__(self, command: str) -> None:
         super().__init__(command,
@@ -79,7 +74,6 @@ class CommandArgumentsError(CommandError):
 
 
 class CommandEvalSyntaxError(CommandError):
-    # pylint: disable=missing-docstring
 
     def __init__(self, command: str, err: SyntaxError) -> None:
         msg = f"{err.msg}:\n\t{err.text}"

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import atexit
 import os
 import readline
@@ -171,7 +169,7 @@ class REPL:
 
         # Force read the variable to capture it
         try:
-            import sdb.target as sdb_target  # pylint: disable=import-outside-toplevel
+            import sdb.target as sdb_target
             obj = sdb_target.get_object(var_name)
             # Use capture_object for proper tracing
             trace_mgr.capture_object(obj, depth)

--- a/sdb/parser.py
+++ b/sdb/parser.py
@@ -153,7 +153,6 @@ def tokenize(line: str) -> Iterable[Tuple[List[str], ExpressionType]]:
     example).
     """
     # pylint: disable=too-many-statements
-    # pylint: disable=too-many-branches
 
     token_list: List[str] = []
     idx: Optional[int] = 0

--- a/sdb/session.py
+++ b/sdb/session.py
@@ -430,7 +430,6 @@ class TraceManager:
             self._log_read(address, data)
             return data
 
-    # pylint: disable=too-many-branches
     def capture_object(self, obj: drgn.Object, depth: int = 1) -> None:
         """
         Capture an object's memory into the trace.
@@ -587,7 +586,6 @@ class TraceManager:
             Number of threads captured.
         """
         # Import here to avoid circular imports and allow use outside kernel context
-        # pylint: disable=import-outside-toplevel
         from drgn.helpers.linux.pid import for_each_task
 
         captured = 0

--- a/sdb/target.py
+++ b/sdb/target.py
@@ -45,7 +45,6 @@ from typing import Any, List, Tuple, Union
 
 import drgn
 
-# pylint: disable=missing-function-docstring
 # pylint: disable=global-statement
 prog: drgn.Program
 thread: int = 0
@@ -234,7 +233,7 @@ def get_runtimes() -> Tuple[bool, List[str]]:
     are made from kernel debugging sessions.
     """
     # Import here to avoid circular dependency
-    from sdb.session import is_replay_mode  # pylint: disable=import-outside-toplevel
+    from sdb.session import is_replay_mode
 
     is_kernel = bool(get_target_flags() & drgn.ProgramFlags.IS_LINUX_KERNEL)
     # In replay mode, treat as kernel session

--- a/tests/integration/gen_regression_output.py
+++ b/tests/integration/gen_regression_output.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-function-docstring
-
 import argparse
 import cProfile
 

--- a/tests/integration/infra.py
+++ b/tests/integration/infra.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-module-docstring
-
 import glob
 import os
 import re

--- a/tests/integration/test_core_generic.py
+++ b/tests/integration/test_core_generic.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-function-docstring
-
 from typing import Any
 
 import pytest

--- a/tests/integration/test_linux_generic.py
+++ b/tests/integration/test_linux_generic.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-function-docstring
 # pylint: disable=line-too-long
 
 from typing import Any, List

--- a/tests/integration/test_mdb_compat_generic.py
+++ b/tests/integration/test_mdb_compat_generic.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-function-docstring
 """
 Integration tests for mdb compatibility syntax.
 

--- a/tests/integration/test_session_tracing.py
+++ b/tests/integration/test_session_tracing.py
@@ -642,7 +642,6 @@ class TestRecordMemory:
             trace_mgr.start_recording(rdump.program, bundle_path)
 
             # Get the address of init_task to record
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
             init_task = sdb_target.get_object("init_task")
             addr = int(init_task.address_of_())
@@ -671,7 +670,6 @@ class TestRecordMemory:
             trace_mgr.start_recording(rdump.program, bundle_path)
 
             # Get the address of init_task
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
             init_task = sdb_target.get_object("init_task")
             addr = int(init_task.address_of_())
@@ -700,7 +698,6 @@ class TestRecordMemory:
             trace_mgr.start_recording(rdump.program, bundle_path)
 
             # Get addresses
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
             init_task = sdb_target.get_object("init_task")
             addr1 = int(init_task.address_of_())
@@ -735,7 +732,6 @@ class TestRecordMemory:
             trace_mgr.start_recording(rdump.program, bundle_path)
 
             # Get address and record
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
             init_task = sdb_target.get_object("init_task")
             addr = int(init_task.address_of_())
@@ -905,7 +901,6 @@ class TestRecordReplayEndToEnd:
 
             # Start recording and capture some objects
             trace_mgr.start_recording(rdump.program, bundle_path)
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
             init_task = sdb_target.get_object("init_task")
             trace_mgr.capture_object(init_task, depth=0)
@@ -939,7 +934,6 @@ class TestRecordReplayEndToEnd:
             bundle_path = os.path.join(tmpdir, "e2e_symbol.sdb")
 
             # Get jiffies address during live mode
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
             jiffies = sdb_target.get_object("jiffies")
             live_jiffies_addr = int(jiffies.address_of_())
@@ -969,7 +963,6 @@ class TestRecordReplayEndToEnd:
         trace_mgr = get_trace_manager()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
             init_task = sdb_target.get_object("init_task")
             addr = int(init_task.address_of_())
@@ -1055,7 +1048,6 @@ class TestRecordReplayEndToEnd:
         trace_mgr = get_trace_manager()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
 
             # Get jiffies value and address during live mode
@@ -1094,7 +1086,6 @@ class TestRecordReplayEndToEnd:
         trace_mgr = get_trace_manager()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # pylint: disable=import-outside-toplevel
             from sdb import target as sdb_target
 
             # Get init_task.comm during live mode
@@ -1250,7 +1241,6 @@ class TestStacksReplay:
             sdb.register_commands()
 
             # Import and test the stacks command directly
-            # pylint: disable=import-outside-toplevel
             from sdb.commands.linux.stacks import KernelStacks
 
             stacks_cmd = KernelStacks()
@@ -1357,7 +1347,6 @@ class TestModuleCommandsReplay:
 
             # Try to access spa_namespace_avl and capture it
             try:
-                # pylint: disable=import-outside-toplevel
                 from sdb import target as sdb_target
                 spa_avl = sdb_target.get_object("spa_namespace_avl")
                 trace_mgr.capture_object(spa_avl, depth=0)
@@ -1397,7 +1386,6 @@ class TestModuleCommandsReplay:
 
             avl_addr = None
             try:
-                # pylint: disable=import-outside-toplevel
                 from sdb import target as sdb_target
                 spa_avl = sdb_target.get_object("spa_namespace_avl")
                 avl_addr = int(spa_avl.address_of_())

--- a/tests/integration/test_spl_generic.py
+++ b/tests/integration/test_spl_generic.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-function-docstring
 # pylint: disable=line-too-long
 
 from typing import Any, List

--- a/tests/integration/test_zfs_generic.py
+++ b/tests/integration/test_zfs_generic.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-function-docstring
 # pylint: disable=line-too-long
 
 from typing import Any

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import Dict, Iterable, List, Optional
 
 import drgn

--- a/tests/unit/commands/test_address.py
+++ b/tests/unit/commands/test_address.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import pytest
 import sdb
 

--- a/tests/unit/commands/test_cast.py
+++ b/tests/unit/commands/test_cast.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import pytest
 import sdb
 

--- a/tests/unit/commands/test_count.py
+++ b/tests/unit/commands/test_count.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import drgn
 
 from tests.unit import invoke, MOCK_PROGRAM

--- a/tests/unit/commands/test_echo.py
+++ b/tests/unit/commands/test_echo.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import pytest
 import drgn
 import sdb

--- a/tests/unit/commands/test_filter.py
+++ b/tests/unit/commands/test_filter.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import pytest
 import drgn
 import sdb

--- a/tests/unit/commands/test_member.py
+++ b/tests/unit/commands/test_member.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import pytest
 import sdb
 

--- a/tests/unit/test_command_validation.py
+++ b/tests/unit/test_command_validation.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import pytest
 
 from sdb.command import is_valid_command_name

--- a/tests/unit/test_mdb_compat.py
+++ b/tests/unit/test_mdb_compat.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 import pytest
 
 from sdb.mdb_compat import (preprocess_mdb_syntax, set_mdb_compat_enabled,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# pylint: disable=missing-docstring
-
 from typing import List, Tuple
 
 import pytest


### PR DESCRIPTION
Disable the most common pylint warnings in CI and remove the matching inline suppression comments across the codebase, then reformat for yapf compliance.