### PR TITLE
tests: add stacks regression outputs

### DIFF
--- a/tests/integration/data/regression_output/dump.201912060006/linux/stacks
+++ b/tests/integration/data/regression_output/dump.201912060006/linux/stacks
@@ -1,0 +1,603 @@
+TASK_STRUCT        STATE             COUNT
+==========================================
+0xffffa08957da8000 INTERRUPTIBLE       164
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  taskq_thread+0x354
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa0893a532e00 INTERRUPTIBLE        70
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  freezable_schedule (inlined)
+                  futex_wait_queue_me+0xc4
+                  futex_wait+0x10a
+                  do_futex+0x364
+                  __do_sys_futex (inlined)
+                  __se_sys_futex (inlined)
+                  __x64_sys_futex+0x13f
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08958085c00 INTERRUPTIBLE        64
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  0xffffffffc090f556+0x0
+                  0xffffffffc0a05667+0x0
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089669edc00 INTERRUPTIBLE        33
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x258
+                  do_epoll_wait+0xb0
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895803c500 INTERRUPTIBLE        33
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  irq_wait_for_interrupt (inlined)
+                  irq_thread+0x9a
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089669eae00 IDLE                 28
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  rescuer_thread+0x310
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089669e9700 IDLE                 23
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  worker_thread+0xbc
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08952ec4500 INTERRUPTIBLE        19
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x258
+                  do_epoll_wait+0xb0
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0893691dc00 INTERRUPTIBLE        18
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  do_wait+0x1cb
+                  kernel_wait4+0x89
+                  __do_sys_wait4+0x95
+                  __se_sys_wait4 (inlined)
+                  __x64_sys_wait4+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08936918000 INTERRUPTIBLE        16
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  pipe_wait+0x70
+                  pipe_read+0x21f
+                  call_read_iter (inlined)
+                  new_sync_read+0x109
+                  __vfs_read+0x29
+                  vfs_read+0x8e
+                  ksys_read+0x5c
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08958081700 INTERRUPTIBLE        14
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3d6
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0x3b
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895684c500 INTERRUPTIBLE        13
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  cv_wait_common+0x11f
+                  __cv_wait_sig+0x15
+                  zthr_procedure+0x51
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08931969700 INTERRUPTIBLE         9
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  freezable_schedule (inlined)
+                  do_nanosleep+0x89
+                  hrtimer_nanosleep+0xd8
+                  __do_sys_nanosleep (inlined)
+                  __se_sys_nanosleep (inlined)
+                  __x64_sys_nanosleep+0x74
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08966a00000 INTERRUPTIBLE         8
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  smpboot_thread_fn+0x169
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08931968000 INTERRUPTIBLE         7
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x60d
+                  core_sys_select+0x1d3
+                  kern_select+0xb7
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x24
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08940965c00 INTERRUPTIBLE         7
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x60d
+                  core_sys_select+0x1d3
+                  kern_select+0xb7
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x24
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0893649ae00 INTERRUPTIBLE         4
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  sigsuspend+0x4a
+                  __do_sys_rt_sigsuspend (inlined)
+                  __se_sys_rt_sigsuspend (inlined)
+                  __x64_sys_rt_sigsuspend+0x4a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895820dc00 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  scsi_error_handler+0x1dd
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08957e3c500 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  cv_wait_common+0x11f
+                  __cv_wait_sig+0x15
+                  txg_thread_wait+0x1d
+                  txg_quiesce_thread+0x152
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08957da9700 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  __cv_timedwait_common+0xdf
+                  __cv_timedwait_sig+0x16
+                  txg_thread_wait+0x31
+                  txg_sync_thread+0x15e
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08952e5ae00 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x11b
+                  cv_timedwait_hires_common+0x4b
+                  cv_timedwait_sig_hires+0x14
+                  mmp_thread+0x2c3
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089320c5c00 INTERRUPTIBLE         2
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  __x64_sys_pause+0x30
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089304eae00 INTERRUPTIBLE         2
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  freezable_schedule_hrtimeout_range (inlined)
+                  do_sigtimedwait+0x18f
+                  __do_sys_rt_sigtimedwait (inlined)
+                  __se_sys_rt_sigtimedwait (inlined)
+                  __x64_sys_rt_sigtimedwait+0x72
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa088ef2d1700 INTERRUPTIBLE         2
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x1db
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x246
+                  inet_accept+0x45
+                  __sys_accept4+0x104
+                  __do_sys_accept (inlined)
+                  __se_sys_accept (inlined)
+                  __x64_sys_accept+0x1c
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089669ec500 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kthreadd+0x2e8
+                  ret_from_fork+0x1f
+
+0xffffa08966a01700 RUNNING               1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  rcu_gp_fqs_loop (inlined)
+                  rcu_gp_kthread+0x572
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966a6dc00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  devtmpfsd+0x159
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966a6ae00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  rcu_tasks_kthread+0x391
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966a68000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kauditd_thread+0x18e
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bcae00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  schedule_timeout_interruptible+0x1f
+                  watchdog+0x5a
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bc8000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  oom_reaper+0x13a
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bcdc00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kcompactd+0x166
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bcc500 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  ksm_scan_thread+0x210
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bd2e00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  khugepaged_wait_work (inlined)
+                  khugepaged+0x403
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089666d1700 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kthread_worker_fn+0x1ae
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966791700 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kswapd_try_to_sleep (inlined)
+                  kswapd+0x3f1
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089587bc500 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  ecryptfs_threadfn+0x139
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08956849700 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x11b
+                  cv_timedwait_hires_common+0x4b
+                  cv_timedwait_sig_hires+0x14
+                  zthr_procedure+0xa4
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa0895684dc00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x11b
+                  cv_timedwait_hires_common+0x4b
+                  cv_timedwait_sig_hires+0x14
+                  dbuf_evict_thread+0x5e
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089580b1700 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  __cv_timedwait_common+0xdf
+                  __cv_timedwait_sig+0x16
+                  l2arc_feed_thread+0x66
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089320e4500 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3d6
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0xa3
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089408fdc00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  cv_wait_common+0x11f
+                  __cv_wait_sig+0x15
+                  zfs_zevent_wait+0x45
+                  zfs_ioc_events_next+0x64
+                  zfsdev_ioctl_common+0x529
+                  zfsdev_ioctl+0x52
+                  vfs_ioctl (inlined)
+                  do_vfs_ioctl+0xa9
+                  ksys_ioctl+0x75
+                  __do_sys_ioctl (inlined)
+                  __se_sys_ioctl (inlined)
+                  __x64_sys_ioctl+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089408f4500 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  do_syslog+0x7ef
+                  do_syslog+0x36
+                  kmsg_read+0x44
+                  proc_reg_read+0x3e
+                  __vfs_read+0x1b
+                  vfs_read+0x8e
+                  ksys_read+0x5c
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895541ae00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x1db
+                  __skb_wait_for_more_packets+0x11f
+                  __skb_recv_datagram+0x6f
+                  skb_recv_datagram+0x3f
+                  netlink_recvmsg+0x57
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x43
+                  ___sys_recvmsg+0xf5
+                  __sys_recvmsg+0x60
+                  __do_sys_recvmsg (inlined)
+                  __se_sys_recvmsg (inlined)
+                  __x64_sys_recvmsg+0x1f
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08905909700 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x1db
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x246
+                  inet_accept+0x45
+                  kernel_accept+0x59
+                  0xffffffffc0d66f63+0x0
+                  0xffffffffc0d67831+0x0
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa0888cc64500 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x60d
+                  core_sys_select+0x1d3
+                  do_pselect (inlined)
+                  __do_sys_pselect6 (inlined)
+                  __se_sys_pselect6 (inlined)
+                  __x64_sys_pselect6+0x126
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08941afae00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  eventfd_read+0x189
+                  __vfs_read+0x1b
+                  vfs_read+0x8e
+                  ksys_read+0x5c
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0888cc62e00 RUNNING               1
+                  freelist_ptr (inlined)
+                  set_freepointer (inlined)
+                  shuffle_freelist (inlined)
+                  allocate_slab (inlined)
+                  new_slab+0x240
+                  new_slab_objects (inlined)
+                  ___slab_alloc+0x393
+                  __slab_alloc+0x20
+                  slab_alloc_node (inlined)
+                  slab_alloc (inlined)
+                  kmem_cache_alloc+0x182
+                  spl_kmem_cache_alloc+0x46
+                  zio_data_buf_alloc+0x55
+                  zil_itx_create+0x29
+                  zfs_log_write+0x124
+                  zfs_write+0x68c
+                  zpl_write_common_iovec+0xa5
+                  zpl_iter_write_common+0x81
+                  zpl_iter_write+0x4f
+                  call_write_iter (inlined)
+                  new_sync_write+0x10c
+                  __vfs_write+0x29
+                  vfs_write+0xb1
+                  ksys_write+0x5c
+                  __do_sys_write (inlined)
+                  __se_sys_write (inlined)
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08884831700 RUNNING               1
+                  crash_setup_regs (inlined)
+                  __crash_kexec+0x9d
+                  panic+0x10e
+                  sysrq_handle_crash+0x15
+                  __handle_sysrq+0x9f
+                  write_sysrq_trigger+0x34
+                  proc_reg_write+0x3e
+                  __vfs_write+0x1b
+                  vfs_write+0xb1
+                  ksys_write+0x5c
+                  __do_sys_write (inlined)
+                  __se_sys_write (inlined)
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+@#$ EXIT CODE $#@
+0

--- a/tests/integration/data/regression_output/dump.201912060006/linux/stacks -a
+++ b/tests/integration/data/regression_output/dump.201912060006/linux/stacks -a
@@ -1,0 +1,1127 @@
+TASK_STRUCT        STATE           
+==========================================
+0xffffa08957da8000 INTERRUPTIBLE   
+0xffffa08957dadc00
+0xffffa08957dac500
+0xffffa08957daae00
+0xffffa08966792e00
+0xffffa08956848000
+0xffffa0895684ae00
+0xffffa089580b2e00
+0xffffa089587bae00
+0xffffa089587b8000
+0xffffa08957dbc500
+0xffffa08957dbae00
+0xffffa08957db9700
+0xffffa08957db0000
+0xffffa08957db1700
+0xffffa08957db2e00
+0xffffa08957db4500
+0xffffa08953515c00
+0xffffa08953514500
+0xffffa08953512e00
+0xffffa08953510000
+0xffffa08953511700
+0xffffa0895350ae00
+0xffffa08953508000
+0xffffa08953509700
+0xffffa0895350dc00
+0xffffa0895350c500
+0xffffa089534b4500
+0xffffa089534b2e00
+0xffffa089534b0000
+0xffffa089534b1700
+0xffffa089534b5c00
+0xffffa089534a2e00
+0xffffa089534a0000
+0xffffa089534a1700
+0xffffa089534a5c00
+0xffffa089534a4500
+0xffffa08953474500
+0xffffa08953472e00
+0xffffa08953470000
+0xffffa08953471700
+0xffffa08953475c00
+0xffffa0895346c500
+0xffffa0895346ae00
+0xffffa08953468000
+0xffffa08953469700
+0xffffa0895346dc00
+0xffffa089533fdc00
+0xffffa089533fc500
+0xffffa089533fae00
+0xffffa089533f8000
+0xffffa089533f9700
+0xffffa08952e71700
+0xffffa08952e75c00
+0xffffa08952e70000
+0xffffa0894e7b2e00
+0xffffa0894e7f4500
+0xffffa0894e7f2e00
+0xffffa0894e7f0000
+0xffffa0894e7f1700
+0xffffa0894e7f5c00
+0xffffa0894e7fdc00
+0xffffa0894e7fc500
+0xffffa0894e7fae00
+0xffffa0894e7f8000
+0xffffa0894e7f9700
+0xffffa0894ea71700
+0xffffa0894ea75c00
+0xffffa0894ea74500
+0xffffa0894ea72e00
+0xffffa0894ea70000
+0xffffa0894ea7dc00
+0xffffa0894ea7c500
+0xffffa0894ea7ae00
+0xffffa0894ea78000
+0xffffa0894ea79700
+0xffffa0894eaaae00
+0xffffa0894eaa8000
+0xffffa0894eaa9700
+0xffffa0894eaadc00
+0xffffa0894eaac500
+0xffffa0894eabae00
+0xffffa0894eab8000
+0xffffa0894eab9700
+0xffffa0894eabdc00
+0xffffa0894eabc500
+0xffffa0894eb61700
+0xffffa0894eb65c00
+0xffffa0894eb64500
+0xffffa0894eb62e00
+0xffffa0894eb60000
+0xffffa0894eb69700
+0xffffa0894eb6dc00
+0xffffa0894eb6c500
+0xffffa0894eb6ae00
+0xffffa0894ebb2e00
+0xffffa0894ebb0000
+0xffffa0894ebb1700
+0xffffa0894ebb4500
+0xffffa0894ebb5c00
+0xffffa0893085c500
+0xffffa08930858000
+0xffffa0893c088000
+0xffffa0893c08dc00
+0xffffa0893c089700
+0xffffa089481b8000
+0xffffa089481bae00
+0xffffa089481bdc00
+0xffffa089481bc500
+0xffffa089481b9700
+0xffffa08940964500
+0xffffa088c58adc00
+0xffffa088c58a8000
+0xffffa088c58a9700
+0xffffa088c58ac500
+0xffffa0893c2b0000
+0xffffa089320e2e00
+0xffffa0890590ae00
+0xffffa08952ec1700
+0xffffa08951028000
+0xffffa08951029700
+0xffffa0895102dc00
+0xffffa0895102c500
+0xffffa0895102ae00
+0xffffa0888c779700
+0xffffa0888c77dc00
+0xffffa0888c77c500
+0xffffa0888c77ae00
+0xffffa0888c778000
+0xffffa08941a69700
+0xffffa08941a6dc00
+0xffffa08941a6c500
+0xffffa08941a6ae00
+0xffffa08941a68000
+0xffffa0889bef1700
+0xffffa0889bef5c00
+0xffffa0889bef4500
+0xffffa0889bef2e00
+0xffffa0889bef0000
+0xffffa0889c9eae00
+0xffffa0889c9e8000
+0xffffa0889c9e9700
+0xffffa08953ac5c00
+0xffffa0889c9edc00
+0xffffa08953acae00
+0xffffa08953ac8000
+0xffffa0895a31c500
+0xffffa0895a319700
+0xffffa0895a31ae00
+0xffffa08959894500
+0xffffa0888c784500
+0xffffa088ce681700
+0xffffa0894e6a8000
+0xffffa0888d2cae00
+0xffffa088ce682e00
+0xffffa08953ac9700
+0xffffa08953acdc00
+0xffffa0889c9ec500
+0xffffa08883df2e00
+0xffffa08883df4500
+0xffffa0888d2cc500
+0xffffa0888d2c8000
+0xffffa0888d2fdc00
+0xffffa087d20edc00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  taskq_thread+0x354
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa0893a532e00 INTERRUPTIBLE   
+0xffffa0895601dc00
+0xffffa08956018000
+0xffffa08956019700
+0xffffa0895601c500
+0xffffa0895601ae00
+0xffffa089560c1700
+0xffffa089560c4500
+0xffffa089560c2e00
+0xffffa08930859700
+0xffffa0895541dc00
+0xffffa089410b9700
+0xffffa089410bae00
+0xffffa08960a38000
+0xffffa08960a3dc00
+0xffffa08960a3ae00
+0xffffa08960a3c500
+0xffffa088ef2d5c00
+0xffffa088ef2d2e00
+0xffffa088ef2d0000
+0xffffa088ef2d4500
+0xffffa088f097dc00
+0xffffa088f097ae00
+0xffffa088f0978000
+0xffffa088f6e5c500
+0xffffa08960a39700
+0xffffa08960a20000
+0xffffa088f6e5dc00
+0xffffa0889cd48000
+0xffffa088f6e5ae00
+0xffffa088f6e59700
+0xffffa0889cd4ae00
+0xffffa088d33d1700
+0xffffa088d33d2e00
+0xffffa088d33d5c00
+0xffffa088d33d0000
+0xffffa0889cd4c500
+0xffffa0889cd49700
+0xffffa08889c92e00
+0xffffa08889c95c00
+0xffffa08889c91700
+0xffffa088d33d4500
+0xffffa088f6e58000
+0xffffa0889366c500
+0xffffa08896518000
+0xffffa0889651dc00
+0xffffa08896519700
+0xffffa0889651ae00
+0xffffa0889651c500
+0xffffa0888e8a1700
+0xffffa0888e8a5c00
+0xffffa08889c90000
+0xffffa08893669700
+0xffffa0888e8a0000
+0xffffa08889c94500
+0xffffa0888e8a2e00
+0xffffa0889fdd0000
+0xffffa0889fdd2e00
+0xffffa0889fdd1700
+0xffffa08894a69700
+0xffffa08894a6ae00
+0xffffa08894a68000
+0xffffa08894a6dc00
+0xffffa08893668000
+0xffffa0889fdd5c00
+0xffffa0889fdd4500
+0xffffa08894561700
+0xffffa08888c49700
+0xffffa08888c48000
+0xffffa088ca874500
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  freezable_schedule (inlined)
+                  futex_wait_queue_me+0xc4
+                  futex_wait+0x10a
+                  do_futex+0x364
+                  __do_sys_futex (inlined)
+                  __se_sys_futex (inlined)
+                  __x64_sys_futex+0x13f
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08958085c00 INTERRUPTIBLE   
+0xffffa0894e7b0000
+0xffffa0894e7b5c00
+0xffffa0894e7b1700
+0xffffa0894e7b4500
+0xffffa089580b0000
+0xffffa089580b5c00
+0xffffa089580b4500
+0xffffa089408f9700
+0xffffa089553bdc00
+0xffffa0894e6aae00
+0xffffa0894e6ac500
+0xffffa0894e6adc00
+0xffffa089408fae00
+0xffffa08957e3ae00
+0xffffa089304e9700
+0xffffa08940961700
+0xffffa08940960000
+0xffffa0893bf7ae00
+0xffffa0893bf78000
+0xffffa0893bf79700
+0xffffa0893bf7dc00
+0xffffa0893bf7c500
+0xffffa08957e3dc00
+0xffffa0894eb68000
+0xffffa08958080000
+0xffffa08941f6c500
+0xffffa08941f6ae00
+0xffffa08941f68000
+0xffffa08941f69700
+0xffffa08941f6dc00
+0xffffa08934e00000
+0xffffa08934e01700
+0xffffa08934e05c00
+0xffffa08934e04500
+0xffffa08934e02e00
+0xffffa08934b58000
+0xffffa08934b59700
+0xffffa08934b5dc00
+0xffffa08934b5c500
+0xffffa08934b5ae00
+0xffffa089358f1700
+0xffffa089358f5c00
+0xffffa089358f4500
+0xffffa089358f2e00
+0xffffa089358f0000
+0xffffa0893d89ae00
+0xffffa0893d898000
+0xffffa0893d899700
+0xffffa0893d89dc00
+0xffffa0893f96c500
+0xffffa0893f96ae00
+0xffffa0893f968000
+0xffffa0893f969700
+0xffffa0893f96dc00
+0xffffa0893d89c500
+0xffffa089408f0000
+0xffffa089553aae00
+0xffffa08939f70000
+0xffffa08939f71700
+0xffffa08939f75c00
+0xffffa08939f74500
+0xffffa08939f72e00
+0xffffa0893c08ae00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  0xffffffffc090f556+0x0
+                  0xffffffffc0a05667+0x0
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089669edc00 INTERRUPTIBLE   
+0xffffa089320e1700
+0xffffa0893196dc00
+0xffffa0893085ae00
+0xffffa089408f1700
+0xffffa08940962e00
+0xffffa089408fc500
+0xffffa08952ec2e00
+0xffffa0894cc84500
+0xffffa0889cd4dc00
+0xffffa0895a329700
+0xffffa0895a32dc00
+0xffffa0895a328000
+0xffffa0895a32ae00
+0xffffa08936805c00
+0xffffa08936804500
+0xffffa08936802e00
+0xffffa088be0fc500
+0xffffa088be0fdc00
+0xffffa088be0f9700
+0xffffa088be0fae00
+0xffffa088be0f8000
+0xffffa08889755c00
+0xffffa08889751700
+0xffffa08889752e00
+0xffffa08889750000
+0xffffa08889754500
+0xffffa08888afc500
+0xffffa08888afdc00
+0xffffa08888af9700
+0xffffa0893196c500
+0xffffa088f7408000
+0xffffa08931488000
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x258
+                  do_epoll_wait+0xb0
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895803c500 INTERRUPTIBLE   
+0xffffa0895803dc00
+0xffffa0895803ae00
+0xffffa08958038000
+0xffffa0895802c500
+0xffffa0895802dc00
+0xffffa08958029700
+0xffffa08958028000
+0xffffa0895802ae00
+0xffffa0895809ae00
+0xffffa0895809c500
+0xffffa0895809dc00
+0xffffa08958099700
+0xffffa08958098000
+0xffffa08958031700
+0xffffa08958034500
+0xffffa08958035c00
+0xffffa08958030000
+0xffffa08958032e00
+0xffffa089580e2e00
+0xffffa089580e5c00
+0xffffa089580e1700
+0xffffa089580e0000
+0xffffa089580e4500
+0xffffa08958089700
+0xffffa0895808ae00
+0xffffa0895808dc00
+0xffffa08958088000
+0xffffa0895808c500
+0xffffa0895820c500
+0xffffa0895820ae00
+0xffffa08958208000
+0xffffa089320e5c00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  irq_wait_for_interrupt (inlined)
+                  irq_thread+0x9a
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089669eae00 IDLE            
+0xffffa089669e8000
+0xffffa08966a02e00
+0xffffa08966a6c500
+0xffffa08966bc9700
+0xffffa08966bd0000
+0xffffa08966bd1700
+0xffffa08966bd5c00
+0xffffa08966bd4500
+0xffffa089666d5c00
+0xffffa089666d4500
+0xffffa089666d2e00
+0xffffa089666d0000
+0xffffa08958039700
+0xffffa08958209700
+0xffffa08957d18000
+0xffffa08957d1dc00
+0xffffa08958084500
+0xffffa08957db8000
+0xffffa08957db5c00
+0xffffa089587b9700
+0xffffa08957580000
+0xffffa08966790000
+0xffffa08952e74500
+0xffffa089304e8000
+0xffffa08957e38000
+0xffffa0890590c500
+0xffffa0890590dc00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  rescuer_thread+0x310
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089669e9700 IDLE            
+0xffffa08966a05c00
+0xffffa08966a04500
+0xffffa08966a09700
+0xffffa08966a52e00
+0xffffa08966a69700
+0xffffa08966795c00
+0xffffa08966794500
+0xffffa089587bdc00
+0xffffa08957d1c500
+0xffffa08958082e00
+0xffffa08957dbdc00
+0xffffa08957585c00
+0xffffa08957581700
+0xffffa08957584500
+0xffffa089320e0000
+0xffffa0893085dc00
+0xffffa08952e72e00
+0xffffa089304ec500
+0xffffa08957e39700
+0xffffa08905908000
+0xffffa0893c2b2e00
+0xffffa0893c2b5c00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  worker_thread+0xbc
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08952ec4500 INTERRUPTIBLE   
+0xffffa0894e6a9700
+0xffffa0894cc81700
+0xffffa0894cc82e00
+0xffffa0894cc80000
+0xffffa0894cc85c00
+0xffffa0891e0ec500
+0xffffa08960a24500
+0xffffa08960a25c00
+0xffffa08960a22e00
+0xffffa08960a21700
+0xffffa088f097c500
+0xffffa088f677dc00
+0xffffa088f6779700
+0xffffa088f677c500
+0xffffa088f6778000
+0xffffa088f677ae00
+0xffffa088ca871700
+0xffffa088ca875c00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x258
+                  do_epoll_wait+0xb0
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0893691dc00 INTERRUPTIBLE   
+0xffffa0893691c500
+0xffffa0893691ae00
+0xffffa08933048000
+0xffffa0893304c500
+0xffffa08931d50000
+0xffffa0894b281700
+0xffffa089320c2e00
+0xffffa0896510ae00
+0xffffa0894b285c00
+0xffffa0893649dc00
+0xffffa0893c2b4500
+0xffffa088f740ae00
+0xffffa08894560000
+0xffffa0889445ae00
+0xffffa0888548ae00
+0xffffa0893c08c500
+0xffffa08884830000
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  do_wait+0x1cb
+                  kernel_wait4+0x89
+                  __do_sys_wait4+0x95
+                  __se_sys_wait4 (inlined)
+                  __x64_sys_wait4+0x1e
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08936918000 INTERRUPTIBLE   
+0xffffa08936919700
+0xffffa0893304dc00
+0xffffa08933049700
+0xffffa0893304ae00
+0xffffa089320c0000
+0xffffa0894b282e00
+0xffffa0896510dc00
+0xffffa089405c9700
+0xffffa08965109700
+0xffffa088f740dc00
+0xffffa088f7409700
+0xffffa08894562e00
+0xffffa08894565c00
+0xffffa08894458000
+0xffffa0889445c500
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  pipe_wait+0x70
+                  pipe_read+0x21f
+                  call_read_iter (inlined)
+                  new_sync_read+0x109
+                  __vfs_read+0x29
+                  vfs_read+0x8e
+                  ksys_read+0x5c
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08958081700 INTERRUPTIBLE   
+0xffffa089408f8000
+0xffffa089304edc00
+0xffffa08952ec5c00
+0xffffa08930464500
+0xffffa0894483dc00
+0xffffa08936801700
+0xffffa08950a89700
+0xffffa089410bc500
+0xffffa08960f42e00
+0xffffa088f0979700
+0xffffa0893196ae00
+0xffffa08884834500
+0xffffa08884832e00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3d6
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0x3b
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895684c500 INTERRUPTIBLE   
+0xffffa08952e5dc00
+0xffffa08952e58000
+0xffffa08952e5c500
+0xffffa08952e59700
+0xffffa089553ac500
+0xffffa089553bae00
+0xffffa089553b8000
+0xffffa089553b9700
+0xffffa08883df0000
+0xffffa08883df5c00
+0xffffa08883df1700
+0xffffa08937f4dc00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  cv_wait_common+0x11f
+                  __cv_wait_sig+0x15
+                  zthr_procedure+0x51
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08931969700 INTERRUPTIBLE   
+0xffffa0893dd31700
+0xffffa0893dd34500
+0xffffa0893dd30000
+0xffffa089405cc500
+0xffffa089405cdc00
+0xffffa0896510c500
+0xffffa0894b284500
+0xffffa088f1e95c00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  freezable_schedule (inlined)
+                  do_nanosleep+0x89
+                  hrtimer_nanosleep+0xd8
+                  __do_sys_nanosleep (inlined)
+                  __se_sys_nanosleep (inlined)
+                  __x64_sys_nanosleep+0x74
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08966a00000 INTERRUPTIBLE   
+0xffffa08966a0ae00
+0xffffa08966a08000
+0xffffa08966a0c500
+0xffffa08966a50000
+0xffffa08966a51700
+0xffffa08966a55c00
+0xffffa08966a54500
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  smpboot_thread_fn+0x169
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08931968000 INTERRUPTIBLE   
+0xffffa089408f2e00
+0xffffa089408f5c00
+0xffffa08957d1ae00
+0xffffa08952ec0000
+0xffffa0893c2b1700
+0xffffa088a150ae00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x60d
+                  core_sys_select+0x1d3
+                  kern_select+0xb7
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x24
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08940965c00 INTERRUPTIBLE   
+0xffffa089553bc500
+0xffffa089320c1700
+0xffffa08936800000
+0xffffa088f740c500
+0xffffa08894564500
+0xffffa0889445dc00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x60d
+                  core_sys_select+0x1d3
+                  kern_select+0xb7
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x24
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0893649ae00 INTERRUPTIBLE   
+0xffffa08936498000
+0xffffa089320c4500
+0xffffa0893319dc00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  sigsuspend+0x4a
+                  __do_sys_rt_sigsuspend (inlined)
+                  __se_sys_rt_sigsuspend (inlined)
+                  __x64_sys_rt_sigsuspend+0x4a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895820dc00 INTERRUPTIBLE   
+0xffffa08957d19700
+0xffffa08957582e00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  scsi_error_handler+0x1dd
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08957e3c500 INTERRUPTIBLE   
+0xffffa089553a8000
+0xffffa0895a318000
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  cv_wait_common+0x11f
+                  __cv_wait_sig+0x15
+                  txg_thread_wait+0x1d
+                  txg_quiesce_thread+0x152
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08957da9700 INTERRUPTIBLE   
+0xffffa089553a9700
+0xffffa0895a31dc00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  __cv_timedwait_common+0xdf
+                  __cv_timedwait_sig+0x16
+                  txg_thread_wait+0x31
+                  txg_sync_thread+0x15e
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08952e5ae00 INTERRUPTIBLE   
+0xffffa089553adc00
+0xffffa0888d2cdc00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x11b
+                  cv_timedwait_hires_common+0x4b
+                  cv_timedwait_sig_hires+0x14
+                  mmp_thread+0x2c3
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089320c5c00 INTERRUPTIBLE   
+0xffffa0894b280000
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  __x64_sys_pause+0x30
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089304eae00 INTERRUPTIBLE   
+0xffffa088c58aae00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  freezable_schedule_hrtimeout_range (inlined)
+                  do_sigtimedwait+0x18f
+                  __do_sys_rt_sigtimedwait (inlined)
+                  __se_sys_rt_sigtimedwait (inlined)
+                  __x64_sys_rt_sigtimedwait+0x72
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa088ef2d1700 INTERRUPTIBLE   
+0xffffa088ca872e00
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x1db
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x246
+                  inet_accept+0x45
+                  __sys_accept4+0x104
+                  __do_sys_accept (inlined)
+                  __se_sys_accept (inlined)
+                  __x64_sys_accept+0x1c
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089669ec500 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kthreadd+0x2e8
+                  ret_from_fork+0x1f
+
+0xffffa08966a01700 RUNNING         
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  rcu_gp_fqs_loop (inlined)
+                  rcu_gp_kthread+0x572
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966a6dc00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  devtmpfsd+0x159
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966a6ae00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  rcu_tasks_kthread+0x391
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966a68000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kauditd_thread+0x18e
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bcae00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  schedule_timeout_interruptible+0x1f
+                  watchdog+0x5a
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bc8000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  oom_reaper+0x13a
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bcdc00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kcompactd+0x166
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bcc500 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  ksm_scan_thread+0x210
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966bd2e00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  khugepaged_wait_work (inlined)
+                  khugepaged+0x403
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089666d1700 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kthread_worker_fn+0x1ae
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08966791700 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  kswapd_try_to_sleep (inlined)
+                  kswapd+0x3f1
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089587bc500 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  ecryptfs_threadfn+0x139
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa08956849700 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x11b
+                  cv_timedwait_hires_common+0x4b
+                  cv_timedwait_sig_hires+0x14
+                  zthr_procedure+0xa4
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa0895684dc00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x11b
+                  cv_timedwait_hires_common+0x4b
+                  cv_timedwait_sig_hires+0x14
+                  dbuf_evict_thread+0x5e
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089580b1700 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x169
+                  __cv_timedwait_common+0xdf
+                  __cv_timedwait_sig+0x16
+                  l2arc_feed_thread+0x66
+                  thread_generic_wrapper+0x74
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa089320e4500 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0xb9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3d6
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0xa3
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089408fdc00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  cv_wait_common+0x11f
+                  __cv_wait_sig+0x15
+                  zfs_zevent_wait+0x45
+                  zfs_ioc_events_next+0x64
+                  zfsdev_ioctl_common+0x529
+                  zfsdev_ioctl+0x52
+                  vfs_ioctl (inlined)
+                  do_vfs_ioctl+0xa9
+                  ksys_ioctl+0x75
+                  __do_sys_ioctl (inlined)
+                  __se_sys_ioctl (inlined)
+                  __x64_sys_ioctl+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa089408f4500 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  do_syslog+0x7ef
+                  do_syslog+0x36
+                  kmsg_read+0x44
+                  proc_reg_read+0x3e
+                  __vfs_read+0x1b
+                  vfs_read+0x8e
+                  ksys_read+0x5c
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0895541ae00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x1db
+                  __skb_wait_for_more_packets+0x11f
+                  __skb_recv_datagram+0x6f
+                  skb_recv_datagram+0x3f
+                  netlink_recvmsg+0x57
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x43
+                  ___sys_recvmsg+0xf5
+                  __sys_recvmsg+0x60
+                  __do_sys_recvmsg (inlined)
+                  __se_sys_recvmsg (inlined)
+                  __x64_sys_recvmsg+0x1f
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08905909700 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_timeout+0x1db
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x246
+                  inet_accept+0x45
+                  kernel_accept+0x59
+                  0xffffffffc0d66f63+0x0
+                  0xffffffffc0d67831+0x0
+                  kthread+0x121
+                  ret_from_fork+0x1f
+
+0xffffa0888cc64500 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  schedule_hrtimeout_range_clock+0x181
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x60d
+                  core_sys_select+0x1d3
+                  do_pselect (inlined)
+                  __do_sys_pselect6 (inlined)
+                  __se_sys_pselect6 (inlined)
+                  __x64_sys_pselect6+0x126
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08941afae00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2c0
+                  schedule+0x2c
+                  eventfd_read+0x189
+                  __vfs_read+0x1b
+                  vfs_read+0x8e
+                  ksys_read+0x5c
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa0888cc62e00 RUNNING         
+                  freelist_ptr (inlined)
+                  set_freepointer (inlined)
+                  shuffle_freelist (inlined)
+                  allocate_slab (inlined)
+                  new_slab+0x240
+                  new_slab_objects (inlined)
+                  ___slab_alloc+0x393
+                  __slab_alloc+0x20
+                  slab_alloc_node (inlined)
+                  slab_alloc (inlined)
+                  kmem_cache_alloc+0x182
+                  spl_kmem_cache_alloc+0x46
+                  zio_data_buf_alloc+0x55
+                  zil_itx_create+0x29
+                  zfs_log_write+0x124
+                  zfs_write+0x68c
+                  zpl_write_common_iovec+0xa5
+                  zpl_iter_write_common+0x81
+                  zpl_iter_write+0x4f
+                  call_write_iter (inlined)
+                  new_sync_write+0x10c
+                  __vfs_write+0x29
+                  vfs_write+0xb1
+                  ksys_write+0x5c
+                  __do_sys_write (inlined)
+                  __se_sys_write (inlined)
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+0xffffa08884831700 RUNNING         
+                  crash_setup_regs (inlined)
+                  __crash_kexec+0x9d
+                  panic+0x10e
+                  sysrq_handle_crash+0x15
+                  __handle_sysrq+0x9f
+                  write_sysrq_trigger+0x34
+                  proc_reg_write+0x3e
+                  __vfs_write+0x1b
+                  vfs_write+0xb1
+                  ksys_write+0x5c
+                  __do_sys_write (inlined)
+                  __se_sys_write (inlined)
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x5a
+                  entry_SYSCALL_64+0x7c
+
+@#$ EXIT CODE $#@
+0

--- a/tests/integration/data/regression_output/dump.202303131823/linux/stacks
+++ b/tests/integration/data/regression_output/dump.202303131823/linux/stacks
@@ -1,0 +1,902 @@
+TASK_STRUCT        STATE             COUNT
+==========================================
+0xffff9ac6607dbd00 INTERRUPTIBLE       512
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  svc_get_next_xprt (inlined)
+                  svc_recv+0x457
+                  nfsd+0xd6
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6539b0000 INTERRUPTIBLE       230
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  futex_wait_queue_me+0xbb
+                  futex_wait+0x105
+                  do_futex+0x157
+                  __do_sys_futex (inlined)
+                  __se_sys_futex (inlined)
+                  __x64_sys_futex+0x13f
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac65f35db80 INTERRUPTIBLE       104
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  taskq_thread+0x33b
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6605e5b80 INTERRUPTIBLE        36
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x3bd
+                  do_epoll_wait+0xb8
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac613483d00 INTERRUPTIBLE        31
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  do_wait+0x1c7
+                  kernel_wait4+0xaf
+                  __do_sys_wait4+0x85
+                  __se_sys_wait4 (inlined)
+                  __x64_sys_wait4+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6605e3d00 IDLE                 25
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  rescuer_thread+0x2f4
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac64c889e80 INTERRUPTIBLE        19
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  do_nanosleep+0x87
+                  hrtimer_nanosleep+0xc2
+                  common_nsleep+0x1c
+                  __do_sys_clock_nanosleep (inlined)
+                  __se_sys_clock_nanosleep (inlined)
+                  __x64_sys_clock_nanosleep+0xc6
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac613d5db80 INTERRUPTIBLE        15
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3ee
+                  __do_sys_ppoll (inlined)
+                  __se_sys_ppoll (inlined)
+                  __x64_sys_ppoll+0xa8
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6605f9e80 IDLE                 13
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  worker_thread+0xcf
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6589f8000 INTERRUPTIBLE        12
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  zthr_procedure+0x45
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac658c99e80 INTERRUPTIBLE        11
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3ee
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0x3b
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60e2fbd00 UNINTERRUPTIBLE      11
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  io_schedule_timeout+0x1e
+                  __cv_timedwait_common+0x15e
+                  __cv_timedwait_io+0x19
+                  zio_wait+0x116
+                  dmu_tx_count_write+0x139
+                  dmu_tx_hold_write_by_dnode+0x3b
+                  zfs_write+0x412
+                  zpl_iter_write+0xe6
+                  call_write_iter (inlined)
+                  new_sync_write+0x125
+                  __vfs_write+0x29
+                  vfs_write (inlined)
+                  vfs_write+0xb9
+                  ksys_pwrite64+0x6d
+                  __do_sys_pwrite64 (inlined)
+                  __se_sys_pwrite64 (inlined)
+                  __x64_sys_pwrite64+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6607b9e80 INTERRUPTIBLE         9
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x579
+                  core_sys_select+0x1b1
+                  kern_select+0xb8
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x25
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6123e9e80 INTERRUPTIBLE         9
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  sigsuspend+0x41
+                  __do_sys_rt_sigsuspend (inlined)
+                  __se_sys_rt_sigsuspend (inlined)
+                  __x64_sys_rt_sigsuspend+0x43
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64adb1e80 INTERRUPTIBLE         9
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  pipe_wait+0x6f
+                  pipe_read+0x20b
+                  call_read_iter (inlined)
+                  new_sync_read+0x122
+                  __vfs_read+0x29
+                  vfs_read (inlined)
+                  vfs_read+0xab
+                  ksys_read+0x67
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6607a1e80 INTERRUPTIBLE         8
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x3bd
+                  do_epoll_wait+0xb8
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac65868db80 INTERRUPTIBLE         6
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x579
+                  core_sys_select+0x1b1
+                  kern_select+0xb8
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x25
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac660605b80 INTERRUPTIBLE         5
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  smpboot_thread_fn+0x117
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac64ada5b80 RUNNING               4
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  futex_wait_queue_me+0xbb
+                  futex_wait+0x105
+                  do_futex+0x157
+                  __do_sys_futex (inlined)
+                  __se_sys_futex (inlined)
+                  __x64_sys_futex+0x13f
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6589f9e80 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x119
+                  cv_timedwait_hires_common+0x1f
+                  cv_timedwait_idle_hires+0x66
+                  mmp_thread+0x2be
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac64cba9e80 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  __x64_sys_pause+0x27
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac61c89bd00 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x3bd
+                  do_epoll_wait+0xb8
+                  __do_sys_epoll_pwait (inlined)
+                  __se_sys_epoll_pwait (inlined)
+                  __x64_sys_epoll_pwait+0x4c
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60f245b80 INTERRUPTIBLE         3
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x271
+                  inet_accept+0x45
+                  __sys_accept4+0x109
+                  __do_sys_accept (inlined)
+                  __se_sys_accept (inlined)
+                  __x64_sys_accept+0x1c
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6589fdb80 INTERRUPTIBLE         2
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  txg_thread_wait+0x2e
+                  txg_quiesce_thread+0x137
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607a8000 INTERRUPTIBLE         2
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3ee
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0xa5
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64c88bd00 INTERRUPTIBLE         2
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  freezable_schedule_hrtimeout_range (inlined)
+                  do_sigtimedwait+0x17f
+                  __do_sys_rt_sigtimedwait (inlined)
+                  __se_sys_rt_sigtimedwait (inlined)
+                  __x64_sys_rt_sigtimedwait+0x71
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60d2bdb80 INTERRUPTIBLE         2
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_sig+0x15
+                  bqueue_dequeue+0x73
+                  vdev_object_store_send_thread+0x37
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6148e1e80 RUNNING               2
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  taskq_thread+0x33b
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6605e0000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kthreadd+0x2cb
+                  ret_from_fork+0x1f
+
+0xffff9ac660600000 RUNNING               1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  rcu_gp_kthread+0x8e2
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660659e80 RUNNING               1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  smpboot_thread_fn+0x117
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660661e80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  devtmpfsd+0x2df
+                  devtmpfsd+0x57
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660665b80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  rcu_tasks_kthread+0xbc
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660740000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  kauditd_thread+0x1c6
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660660000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  schedule_timeout_interruptible+0x1f
+                  watchdog+0x78
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660741e80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  oom_reaper+0x172
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660745b80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  kcompactd+0x175
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660799e80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  ksm_scan_thread+0x752
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607a0000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  freezable_schedule_timeout (inlined)
+                  khugepaged_wait_work (inlined)
+                  khugepaged+0x3a9
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac65fc05b80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kthread_worker_fn+0x12b
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607f3d00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kswapd_try_to_sleep (inlined)
+                  kswapd+0x36c
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac65f359e80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x119
+                  cv_timedwait_hires_common+0x56
+                  cv_timedwait_idle_hires+0x66
+                  zthr_procedure+0x96
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607b8000 UNINTERRUPTIBLE       1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  schedule_timeout_uninterruptible+0x1f
+                  arc_reap_cb+0x26
+                  zthr_procedure+0x130
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607b3d00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x119
+                  cv_timedwait_hires_common+0x56
+                  cv_timedwait_idle_hires+0x66
+                  dbuf_evict_thread+0x50
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607ebd00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  __cv_timedwait_common+0xf3
+                  __cv_timedwait_idle+0x59
+                  l2arc_feed_thread+0x64
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac658c30000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  __cv_timedwait_common+0xf3
+                  __cv_timedwait_idle+0x59
+                  txg_thread_wait+0x27
+                  txg_sync_thread+0xfd
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6525cbd00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  __skb_wait_for_more_packets+0x103
+                  __skb_recv_datagram+0x67
+                  skb_recv_datagram+0x3b
+                  unix_accept+0x91
+                  __sys_accept4+0x109
+                  __do_sys_accept4 (inlined)
+                  __se_sys_accept4 (inlined)
+                  __x64_sys_accept4+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6525c8000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_sig+0x15
+                  zfs_zevent_wait+0x3f
+                  zfs_ioc_events_next+0x6f
+                  zfsdev_ioctl_common+0x5df
+                  zfsdev_ioctl+0x57
+                  vfs_ioctl (inlined)
+                  file_ioctl (inlined)
+                  do_vfs_ioctl+0x407
+                  ksys_ioctl+0x67
+                  __do_sys_ioctl (inlined)
+                  __se_sys_ioctl (inlined)
+                  __x64_sys_ioctl+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64cbadb80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  __skb_wait_for_more_packets+0x103
+                  __skb_recv_datagram+0x67
+                  skb_recv_datagram+0x3b
+                  netlink_recvmsg+0x54
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x70
+                  ____sys_recvmsg+0xa4
+                  ___sys_recvmsg+0x7c
+                  __sys_recvmsg+0x59
+                  __do_sys_recvmsg (inlined)
+                  __se_sys_recvmsg (inlined)
+                  __x64_sys_recvmsg+0x1f
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64bfbbd00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  do_syslog+0x846
+                  do_syslog+0x39
+                  kmsg_read+0x43
+                  proc_reg_read+0x43
+                  __vfs_read+0x1b
+                  vfs_read (inlined)
+                  vfs_read+0xab
+                  ksys_read+0x67
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5fcb29e80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kjournald2+0x222
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5fbef8000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x271
+                  inet_accept+0x45
+                  kernel_accept+0x59
+                  iscsit_accept_np+0x38
+                  __iscsi_target_login_thread+0xe7
+                  iscsi_target_login_thread+0x24
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5559c0000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  eventfd_read+0x17d
+                  __vfs_read+0x1b
+                  vfs_read (inlined)
+                  vfs_read+0xab
+                  ksys_read+0x67
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6605fbd00 UNINTERRUPTIBLE       1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_preempt_disabled+0xe
+                  __mutex_lock_common (inlined)
+                  __mutex_lock+0x172
+                  __mutex_lock_slowpath+0x13
+                  mutex_lock+0x2e
+                  free_from_removing_vdev+0x5d
+                  metaslab_free_impl+0xd8
+                  metaslab_free_dva+0x5e
+                  metaslab_free+0x180
+                  zio_free_sync+0xea
+                  zio_free+0xb0
+                  dsl_free+0x11
+                  dsl_dataset_block_kill+0x2a0
+                  dbuf_write_done+0x15e
+                  arc_write_done+0x25a
+                  zio_done+0x3ae
+                  __zio_execute (inlined)
+                  zio_execute+0x92
+                  taskq_thread+0x220
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5bb82db80 UNINTERRUPTIBLE       1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  io_schedule_timeout+0x1e
+                  __cv_timedwait_common+0x15e
+                  __cv_timedwait_io+0x19
+                  zio_wait+0x116
+                  dsl_pool_sync+0xbb
+                  spa_sync_iterate_to_convergence+0xf1
+                  spa_sync+0x31c
+                  txg_sync_thread+0x22d
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac612d00000 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x579
+                  core_sys_select+0x1b1
+                  do_pselect+0xaf
+                  __do_sys_pselect6 (inlined)
+                  __se_sys_pselect6 (inlined)
+                  __x64_sys_pselect6+0x6b
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5a7d23d00 RUNNING               1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  exit_to_usermode_loop+0x82
+                  prepare_exit_to_usermode+0x77
+                  common_interrupt+0x34
+                  0x7fc25ecfa733+0x0
+
+0xffff9ac5a7d21e80 RUNNING               1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  exit_to_usermode_loop+0x82
+                  prepare_exit_to_usermode+0x77
+                  common_interrupt+0x34
+                  0x7fc25f204c0d+0x0
+
+0xffff9ac5a7d25b80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  freezable_schedule_timeout (inlined)
+                  unix_stream_data_wait (inlined)
+                  unix_stream_read_generic+0x656
+                  unix_stream_recvmsg+0x51
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x70
+                  __sys_recvfrom+0x19e
+                  __do_sys_recvfrom (inlined)
+                  __se_sys_recvfrom (inlined)
+                  __x64_sys_recvfrom+0x29
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60d833d00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  freezable_schedule_timeout (inlined)
+                  unix_stream_data_wait (inlined)
+                  unix_stream_read_generic+0x656
+                  unix_stream_recvmsg+0x51
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x70
+                  kernel_recvmsg+0x54
+                  ksock_receive+0x14
+                  zfs_object_store_receive+0x87
+                  agent_receive_all+0x8b
+                  agent_reader+0x43
+                  vdev_object_store_receive_thread+0x95
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac60d831e80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_sig+0x15
+                  bqueue_dequeue+0x73
+                  vdev_object_store_send_thread+0xb8
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5e3061e80 RUNNING               1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  txg_thread_wait+0x2e
+                  txg_quiesce_thread+0x137
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5e3065b80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  txg_thread_wait+0x2e
+                  txg_sync_thread+0x182
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac60e2f8000 RUNNING               1
+                  dbuf_find+0xae
+                  dbuf_hold_impl+0x72
+                  dbuf_hold_level+0x32
+                  dbuf_hold+0x16
+                  dmu_buf_hold_array_by_dnode+0x151
+                  dmu_write_uio_dnode+0x4c
+                  dmu_write_uio_dbuf+0x4f
+                  zfs_write+0x4d1
+                  zpl_iter_write+0xe6
+                  call_write_iter (inlined)
+                  new_sync_write+0x125
+                  __vfs_write+0x29
+                  vfs_write (inlined)
+                  vfs_write+0xb9
+                  ksys_pwrite64+0x6d
+                  __do_sys_pwrite64 (inlined)
+                  __se_sys_pwrite64 (inlined)
+                  __x64_sys_pwrite64+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5fef15b80 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  iscsi_target_tx_thread+0x1d2
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5fef13d00 INTERRUPTIBLE         1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  wait_woken+0x48
+                  sk_wait_data+0x123
+                  tcp_recvmsg+0x5a7
+                  inet_recvmsg+0x5e
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x69
+                  iscsit_do_rx_data+0x90
+                  rx_data+0x5f
+                  iscsit_get_rx_pdu+0xd2
+                  iscsi_target_rx_thread+0x94
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5b7539e80 RUNNING               1
+                  crash_setup_regs (inlined)
+                  __crash_kexec+0x9d
+                  panic+0x11d
+                  sysrq_handle_crash+0x15
+                  __handle_sysrq+0x48
+                  write_sysrq_trigger+0x28
+                  proc_reg_write+0x43
+                  __vfs_write+0x1b
+                  vfs_write (inlined)
+                  vfs_write+0xb9
+                  ksys_write+0x67
+                  __do_sys_write (inlined)
+                  __se_sys_write (inlined)
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5fbcf3d00 RUNNING               1
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  preempt_schedule_common+0x18
+                  _cond_resched+0x22
+                  slab_pre_alloc_hook (inlined)
+                  slab_alloc_node (inlined)
+                  slab_alloc (inlined)
+                  kmem_cache_alloc+0x1ea
+                  spl_kmem_cache_alloc+0x3b
+                  zfs_btree_leaf_alloc+0x39
+                  zfs_btree_insert_into_leaf+0x1d2
+                  zfs_btree_add_idx+0x15f
+                  range_tree_add_impl+0x49d
+                  range_tree_add+0x11
+                  space_map_load_callback+0x59
+                  space_map_iterate+0x20f
+                  space_map_load_length+0x61
+                  space_map_load+0x2e
+                  spa_vdev_remove_thread+0x18f
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+@#$ EXIT CODE $#@
+0

--- a/tests/integration/data/regression_output/dump.202303131823/linux/stacks -a
+++ b/tests/integration/data/regression_output/dump.202303131823/linux/stacks -a
@@ -1,0 +1,1965 @@
+TASK_STRUCT        STATE           
+==========================================
+0xffff9ac6607dbd00 INTERRUPTIBLE   
+0xffff9ac64adb0000
+0xffff9ac64adb3d00
+0xffff9ac64c888000
+0xffff9ac6607b1e80
+0xffff9ac6607bbd00
+0xffff9ac66079db80
+0xffff9ac6591e9e80
+0xffff9ac658c9db80
+0xffff9ac642940000
+0xffff9ac642943d00
+0xffff9ac642941e80
+0xffff9ac642945b80
+0xffff9ac642589e80
+0xffff9ac64258db80
+0xffff9ac642588000
+0xffff9ac64258bd00
+0xffff9ac642195b80
+0xffff9ac642190000
+0xffff9ac642193d00
+0xffff9ac642191e80
+0xffff9ac641de5b80
+0xffff9ac641de0000
+0xffff9ac641de3d00
+0xffff9ac641de1e80
+0xffff9ac641a2bd00
+0xffff9ac641a29e80
+0xffff9ac641a2db80
+0xffff9ac641a28000
+0xffff9ac64163bd00
+0xffff9ac641639e80
+0xffff9ac64163db80
+0xffff9ac641638000
+0xffff9ac641285b80
+0xffff9ac641280000
+0xffff9ac641283d00
+0xffff9ac641281e80
+0xffff9ac640ed5b80
+0xffff9ac640ed0000
+0xffff9ac640ed3d00
+0xffff9ac640ed1e80
+0xffff9ac640ad9e80
+0xffff9ac640addb80
+0xffff9ac640ad8000
+0xffff9ac640adbd00
+0xffff9ac640725b80
+0xffff9ac640720000
+0xffff9ac640723d00
+0xffff9ac640721e80
+0xffff9ac640335b80
+0xffff9ac640330000
+0xffff9ac640333d00
+0xffff9ac640331e80
+0xffff9ac63ff78000
+0xffff9ac63ff7bd00
+0xffff9ac63ff79e80
+0xffff9ac63ff7db80
+0xffff9ac63fbc9e80
+0xffff9ac63fbcdb80
+0xffff9ac63fbc8000
+0xffff9ac63fbcbd00
+0xffff9ac63f7d3d00
+0xffff9ac63f7d1e80
+0xffff9ac63f7d5b80
+0xffff9ac63f7d0000
+0xffff9ac63ec21e80
+0xffff9ac63ec25b80
+0xffff9ac63ec20000
+0xffff9ac63ec23d00
+0xffff9ac63e86bd00
+0xffff9ac63e869e80
+0xffff9ac63e86db80
+0xffff9ac63e868000
+0xffff9ac63e479e80
+0xffff9ac63e47db80
+0xffff9ac63e478000
+0xffff9ac63e47bd00
+0xffff9ac63e0c5b80
+0xffff9ac63e0c0000
+0xffff9ac63e0c3d00
+0xffff9ac63e0c1e80
+0xffff9ac63dd15b80
+0xffff9ac63dd10000
+0xffff9ac63dd13d00
+0xffff9ac63dd11e80
+0xffff9ac63d919e80
+0xffff9ac63d91db80
+0xffff9ac63d918000
+0xffff9ac63d91bd00
+0xffff9ac63d561e80
+0xffff9ac63d565b80
+0xffff9ac63d560000
+0xffff9ac63d563d00
+0xffff9ac63d1abd00
+0xffff9ac63d1a9e80
+0xffff9ac63d1adb80
+0xffff9ac63d1a8000
+0xffff9ac63cdc3d00
+0xffff9ac63cdc1e80
+0xffff9ac63cdc5b80
+0xffff9ac63cdc0000
+0xffff9ac63ca0bd00
+0xffff9ac63ca09e80
+0xffff9ac63ca0db80
+0xffff9ac63ca08000
+0xffff9ac63c611e80
+0xffff9ac63c615b80
+0xffff9ac63c610000
+0xffff9ac63c613d00
+0xffff9ac63c260000
+0xffff9ac63c263d00
+0xffff9ac63c261e80
+0xffff9ac63c265b80
+0xffff9ac63bea9e80
+0xffff9ac63beadb80
+0xffff9ac63bea8000
+0xffff9ac63beabd00
+0xffff9ac63bab0000
+0xffff9ac63bab3d00
+0xffff9ac63bab1e80
+0xffff9ac63bab5b80
+0xffff9ac63b705b80
+0xffff9ac63b700000
+0xffff9ac63b703d00
+0xffff9ac63b701e80
+0xffff9ac63b351e80
+0xffff9ac63b355b80
+0xffff9ac63b350000
+0xffff9ac63b353d00
+0xffff9ac63af58000
+0xffff9ac63af5bd00
+0xffff9ac63af59e80
+0xffff9ac63af5db80
+0xffff9ac63aba1e80
+0xffff9ac63aba5b80
+0xffff9ac63aba0000
+0xffff9ac63aba3d00
+0xffff9ac63a7ebd00
+0xffff9ac63a7e9e80
+0xffff9ac63a7edb80
+0xffff9ac63a7e8000
+0xffff9ac639c03d00
+0xffff9ac639c01e80
+0xffff9ac639c05b80
+0xffff9ac639c00000
+0xffff9ac639848000
+0xffff9ac63984bd00
+0xffff9ac639849e80
+0xffff9ac63984db80
+0xffff9ac639495b80
+0xffff9ac639490000
+0xffff9ac639493d00
+0xffff9ac639491e80
+0xffff9ac6390a3d00
+0xffff9ac6390a1e80
+0xffff9ac6390a5b80
+0xffff9ac6390a0000
+0xffff9ac638cf1e80
+0xffff9ac638cf5b80
+0xffff9ac638cf0000
+0xffff9ac638cf3d00
+0xffff9ac638933d00
+0xffff9ac638931e80
+0xffff9ac638935b80
+0xffff9ac638930000
+0xffff9ac638539e80
+0xffff9ac63853db80
+0xffff9ac638538000
+0xffff9ac63853bd00
+0xffff9ac638191e80
+0xffff9ac638195b80
+0xffff9ac638190000
+0xffff9ac638193d00
+0xffff9ac637da3d00
+0xffff9ac637da1e80
+0xffff9ac637da5b80
+0xffff9ac637da0000
+0xffff9ac6379edb80
+0xffff9ac6379e8000
+0xffff9ac6379ebd00
+0xffff9ac6379e9e80
+0xffff9ac64aed1e80
+0xffff9ac64adb5b80
+0xffff9ac637040000
+0xffff9ac637043d00
+0xffff9ac637041e80
+0xffff9ac637045b80
+0xffff9ac636c48000
+0xffff9ac636c4bd00
+0xffff9ac636c49e80
+0xffff9ac636c4db80
+0xffff9ac636890000
+0xffff9ac636893d00
+0xffff9ac636891e80
+0xffff9ac636895b80
+0xffff9ac6364e9e80
+0xffff9ac6364edb80
+0xffff9ac6364e8000
+0xffff9ac6364ebd00
+0xffff9ac6360fbd00
+0xffff9ac6360f9e80
+0xffff9ac6360fdb80
+0xffff9ac6360f8000
+0xffff9ac635d3bd00
+0xffff9ac635d39e80
+0xffff9ac635f40000
+0xffff9ac635d3db80
+0xffff9ac635d38000
+0xffff9ac635a8bd00
+0xffff9ac635a89e80
+0xffff9ac635a8db80
+0xffff9ac635f43d00
+0xffff9ac635a88000
+0xffff9ac6357a0000
+0xffff9ac6357a3d00
+0xffff9ac6357a1e80
+0xffff9ac6357a5b80
+0xffff9ac6353edb80
+0xffff9ac6353e8000
+0xffff9ac6353ebd00
+0xffff9ac6353e9e80
+0xffff9ac634835b80
+0xffff9ac634830000
+0xffff9ac634833d00
+0xffff9ac634831e80
+0xffff9ac634445b80
+0xffff9ac634440000
+0xffff9ac634443d00
+0xffff9ac634441e80
+0xffff9ac634091e80
+0xffff9ac634095b80
+0xffff9ac634090000
+0xffff9ac634093d00
+0xffff9ac633cddb80
+0xffff9ac633cd8000
+0xffff9ac633cdbd00
+0xffff9ac633cd9e80
+0xffff9ac6338e1e80
+0xffff9ac6338e5b80
+0xffff9ac6338e0000
+0xffff9ac6338e3d00
+0xffff9ac633531e80
+0xffff9ac633535b80
+0xffff9ac633530000
+0xffff9ac633533d00
+0xffff9ac633180000
+0xffff9ac633183d00
+0xffff9ac633181e80
+0xffff9ac633185b80
+0xffff9ac632d88000
+0xffff9ac632d8bd00
+0xffff9ac632d89e80
+0xffff9ac632d8db80
+0xffff9ac6329c9e80
+0xffff9ac6329cdb80
+0xffff9ac6329c8000
+0xffff9ac6329cbd00
+0xffff9ac632623d00
+0xffff9ac632621e80
+0xffff9ac632625b80
+0xffff9ac632620000
+0xffff9ac632229e80
+0xffff9ac63222db80
+0xffff9ac632228000
+0xffff9ac63222bd00
+0xffff9ac631e73d00
+0xffff9ac631e71e80
+0xffff9ac631e75b80
+0xffff9ac631e70000
+0xffff9ac631a79e80
+0xffff9ac631a7db80
+0xffff9ac631a78000
+0xffff9ac631a7bd00
+0xffff9ac6316d5b80
+0xffff9ac6316d0000
+0xffff9ac6316d3d00
+0xffff9ac6316d1e80
+0xffff9ac631318000
+0xffff9ac63131bd00
+0xffff9ac631319e80
+0xffff9ac63131db80
+0xffff9ac630f20000
+0xffff9ac630f23d00
+0xffff9ac630f21e80
+0xffff9ac630f25b80
+0xffff9ac630b7bd00
+0xffff9ac630b79e80
+0xffff9ac630b7db80
+0xffff9ac630b78000
+0xffff9ac6307b8000
+0xffff9ac6307bbd00
+0xffff9ac6307b9e80
+0xffff9ac6307bdb80
+0xffff9ac6303cbd00
+0xffff9ac6303c9e80
+0xffff9ac6303cdb80
+0xffff9ac6303c8000
+0xffff9ac62f815b80
+0xffff9ac62f810000
+0xffff9ac62f813d00
+0xffff9ac62f811e80
+0xffff9ac62f460000
+0xffff9ac62f463d00
+0xffff9ac62f461e80
+0xffff9ac62f465b80
+0xffff9ac62f068000
+0xffff9ac62f06bd00
+0xffff9ac62f069e80
+0xffff9ac62f06db80
+0xffff9ac62ecb8000
+0xffff9ac62ecbbd00
+0xffff9ac62ecb9e80
+0xffff9ac62ecbdb80
+0xffff9ac62e903d00
+0xffff9ac62e901e80
+0xffff9ac62e905b80
+0xffff9ac62e900000
+0xffff9ac62e515b80
+0xffff9ac62e510000
+0xffff9ac62e513d00
+0xffff9ac62e511e80
+0xffff9ac62e15db80
+0xffff9ac62e158000
+0xffff9ac62e15bd00
+0xffff9ac62e159e80
+0xffff9ac62dda1e80
+0xffff9ac62dda5b80
+0xffff9ac62dda0000
+0xffff9ac62dda3d00
+0xffff9ac62d9b5b80
+0xffff9ac62d9b0000
+0xffff9ac62d9b3d00
+0xffff9ac62d9b1e80
+0xffff9ac62d605b80
+0xffff9ac62d600000
+0xffff9ac62d603d00
+0xffff9ac62d601e80
+0xffff9ac62d243d00
+0xffff9ac62d241e80
+0xffff9ac62d245b80
+0xffff9ac62d240000
+0xffff9ac62ce50000
+0xffff9ac62ce53d00
+0xffff9ac62ce51e80
+0xffff9ac62ce55b80
+0xffff9ac62caa0000
+0xffff9ac62caa3d00
+0xffff9ac62caa1e80
+0xffff9ac62caa5b80
+0xffff9ac62c6adb80
+0xffff9ac62c6a8000
+0xffff9ac62c6abd00
+0xffff9ac62c6a9e80
+0xffff9ac62c2f1e80
+0xffff9ac62c2f5b80
+0xffff9ac62c2f0000
+0xffff9ac62c2f3d00
+0xffff9ac62bf40000
+0xffff9ac62bf43d00
+0xffff9ac62bf41e80
+0xffff9ac62bf45b80
+0xffff9ac62bb51e80
+0xffff9ac62bb55b80
+0xffff9ac62bb50000
+0xffff9ac62bb53d00
+0xffff9ac62b799e80
+0xffff9ac62b79db80
+0xffff9ac62b798000
+0xffff9ac62b79bd00
+0xffff9ac62b3e1e80
+0xffff9ac62b3e5b80
+0xffff9ac62b3e0000
+0xffff9ac62b3e3d00
+0xffff9ac62aff0000
+0xffff9ac62aff3d00
+0xffff9ac62aff1e80
+0xffff9ac62aff5b80
+0xffff9ac62a441e80
+0xffff9ac62a445b80
+0xffff9ac62a440000
+0xffff9ac62a443d00
+0xffff9ac62a088000
+0xffff9ac62a08bd00
+0xffff9ac62a089e80
+0xffff9ac62a08db80
+0xffff9ac629c90000
+0xffff9ac629c93d00
+0xffff9ac629c91e80
+0xffff9ac629c95b80
+0xffff9ac6298dbd00
+0xffff9ac6298d9e80
+0xffff9ac6298ddb80
+0xffff9ac6298d8000
+0xffff9ac629529e80
+0xffff9ac62952db80
+0xffff9ac629528000
+0xffff9ac62952bd00
+0xffff9ac629138000
+0xffff9ac62913bd00
+0xffff9ac629139e80
+0xffff9ac62913db80
+0xffff9ac628d80000
+0xffff9ac628d83d00
+0xffff9ac628d81e80
+0xffff9ac628d85b80
+0xffff9ac6289d5b80
+0xffff9ac6289d0000
+0xffff9ac6289d3d00
+0xffff9ac6289d1e80
+0xffff9ac6285d9e80
+0xffff9ac6285ddb80
+0xffff9ac6285d8000
+0xffff9ac6285dbd00
+0xffff9ac628221e80
+0xffff9ac628225b80
+0xffff9ac628220000
+0xffff9ac628223d00
+0xffff9ac627e2db80
+0xffff9ac627e28000
+0xffff9ac627e2bd00
+0xffff9ac627e29e80
+0xffff9ac627a80000
+0xffff9ac627a83d00
+0xffff9ac627a81e80
+0xffff9ac627a85b80
+0xffff9ac6276c9e80
+0xffff9ac6276cdb80
+0xffff9ac6276c8000
+0xffff9ac6276cbd00
+0xffff9ac6272d1e80
+0xffff9ac6272d5b80
+0xffff9ac6272d0000
+0xffff9ac6272d3d00
+0xffff9ac626f1db80
+0xffff9ac626f18000
+0xffff9ac626f1bd00
+0xffff9ac626f19e80
+0xffff9ac626b6db80
+0xffff9ac626b68000
+0xffff9ac626b6bd00
+0xffff9ac626b69e80
+0xffff9ac62677bd00
+0xffff9ac626779e80
+0xffff9ac62677db80
+0xffff9ac626778000
+0xffff9ac6263c3d00
+0xffff9ac6263c1e80
+0xffff9ac6263c5b80
+0xffff9ac6263c0000
+0xffff9ac62541db80
+0xffff9ac625418000
+0xffff9ac62541bd00
+0xffff9ac625419e80
+0xffff9ac625033d00
+0xffff9ac625031e80
+0xffff9ac625035b80
+0xffff9ac625030000
+0xffff9ac624c79e80
+0xffff9ac624c7db80
+0xffff9ac624c78000
+0xffff9ac624c7bd00
+0xffff9ac6248c1e80
+0xffff9ac6248c5b80
+0xffff9ac6248c0000
+0xffff9ac6248c3d00
+0xffff9ac6244f5b80
+0xffff9ac6244f0000
+0xffff9ac6244f3d00
+0xffff9ac6244f1e80
+0xffff9ac6241a0000
+0xffff9ac6241a3d00
+0xffff9ac6241a1e80
+0xffff9ac6241a5b80
+0xffff9ac623debd00
+0xffff9ac623de9e80
+0xffff9ac623dedb80
+0xffff9ac623de8000
+0xffff9ac623a31e80
+0xffff9ac623a35b80
+0xffff9ac623a30000
+0xffff9ac623a33d00
+0xffff9ac62364db80
+0xffff9ac623648000
+0xffff9ac62364bd00
+0xffff9ac623649e80
+0xffff9ac623295b80
+0xffff9ac623290000
+0xffff9ac623293d00
+0xffff9ac623291e80
+0xffff9ac622ed1e80
+0xffff9ac622ed5b80
+0xffff9ac622ed0000
+0xffff9ac622ed3d00
+0xffff9ac622ad9e80
+0xffff9ac622addb80
+0xffff9ac622ad8000
+0xffff9ac622adbd00
+0xffff9ac622735b80
+0xffff9ac622730000
+0xffff9ac622733d00
+0xffff9ac622731e80
+0xffff9ac62237bd00
+0xffff9ac622379e80
+0xffff9ac62237db80
+0xffff9ac622378000
+0xffff9ac621f80000
+0xffff9ac621f83d00
+0xffff9ac621f81e80
+0xffff9ac621f85b80
+0xffff9ac621bd5b80
+0xffff9ac621bd0000
+0xffff9ac621bd3d00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  svc_get_next_xprt (inlined)
+                  svc_recv+0x457
+                  nfsd+0xd6
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6539b0000 INTERRUPTIBLE   
+0xffff9ac658c33d00
+0xffff9ac64c919e80
+0xffff9ac64c91bd00
+0xffff9ac64c91db80
+0xffff9ac64c918000
+0xffff9ac64ca50000
+0xffff9ac64ca51e80
+0xffff9ac64ca53d00
+0xffff9ac64ca55b80
+0xffff9ac64cba8000
+0xffff9ac64bfb8000
+0xffff9ac64a4c3d00
+0xffff9ac64a4c1e80
+0xffff9ac621bd1e80
+0xffff9ac621203d00
+0xffff9ac621201e80
+0xffff9ac62120db80
+0xffff9ac621205b80
+0xffff9ac61c89db80
+0xffff9ac611970000
+0xffff9ac61165db80
+0xffff9ac611975b80
+0xffff9ac611971e80
+0xffff9ac611973d00
+0xffff9ac60da33d00
+0xffff9ac60da30000
+0xffff9ac60da35b80
+0xffff9ac611720000
+0xffff9ac614d1db80
+0xffff9ac611725b80
+0xffff9ac611721e80
+0xffff9ac60da31e80
+0xffff9ac60f243d00
+0xffff9ac60f240000
+0xffff9ac614d18000
+0xffff9ac6134d5b80
+0xffff9ac611715b80
+0xffff9ac611711e80
+0xffff9ac611af5b80
+0xffff9ac612625b80
+0xffff9ac612621e80
+0xffff9ac612620000
+0xffff9ac602d79e80
+0xffff9ac602d7bd00
+0xffff9ac602d78000
+0xffff9ac602d7db80
+0xffff9ac5ec5a5b80
+0xffff9ac5ec5a1e80
+0xffff9ac5fc9a0000
+0xffff9ac611af0000
+0xffff9ac611af1e80
+0xffff9ac61165bd00
+0xffff9ac5d4160000
+0xffff9ac5d1853d00
+0xffff9ac5d1855b80
+0xffff9ac5d4165b80
+0xffff9ac5d4163d00
+0xffff9ac5d413bd00
+0xffff9ac5d413db80
+0xffff9ac5d4139e80
+0xffff9ac5d1851e80
+0xffff9ac5e0d63d00
+0xffff9ac5e0d61e80
+0xffff9ac5e0d65b80
+0xffff9ac5d4161e80
+0xffff9ac5d19f3d00
+0xffff9ac5d19f1e80
+0xffff9ac5e0c89e80
+0xffff9ac5d19f0000
+0xffff9ac5e0c88000
+0xffff9ac5d4138000
+0xffff9ac5cc3c0000
+0xffff9ac5e0d60000
+0xffff9ac5cc3c1e80
+0xffff9ac60aa80000
+0xffff9ac5cc3c5b80
+0xffff9ac5cc3c3d00
+0xffff9ac60aa83d00
+0xffff9ac5e0dd0000
+0xffff9ac5c67d9e80
+0xffff9ac5c67d8000
+0xffff9ac5c67ddb80
+0xffff9ac546750000
+0xffff9ac5558c3d00
+0xffff9ac5cc073d00
+0xffff9ac5459e9e80
+0xffff9ac611658000
+0xffff9ac648fddb80
+0xffff9ac648fdbd00
+0xffff9ac648fd9e80
+0xffff9ac553d28000
+0xffff9ac553d2bd00
+0xffff9ac5d19f5b80
+0xffff9ac546755b80
+0xffff9ac5e0dd5b80
+0xffff9ac5e0dd3d00
+0xffff9ac546751e80
+0xffff9ac5e0dd1e80
+0xffff9ac546753d00
+0xffff9ac5cc075b80
+0xffff9ac648fd8000
+0xffff9ac645ee5b80
+0xffff9ac54d385b80
+0xffff9ac645ee0000
+0xffff9ac645ee1e80
+0xffff9ac60a58bd00
+0xffff9ac60a589e80
+0xffff9ac600b39e80
+0xffff9ac600b3db80
+0xffff9ac600b38000
+0xffff9ac585160000
+0xffff9ac54d380000
+0xffff9ac54d381e80
+0xffff9ac6112d9e80
+0xffff9ac6085bbd00
+0xffff9ac605e10000
+0xffff9ac605e11e80
+0xffff9ac605e13d00
+0xffff9ac605e15b80
+0xffff9ac5f196bd00
+0xffff9ac5f196db80
+0xffff9ac5f1968000
+0xffff9ac5f1969e80
+0xffff9ac5781abd00
+0xffff9ac5781adb80
+0xffff9ac5781a8000
+0xffff9ac5781a9e80
+0xffff9ac576f30000
+0xffff9ac576f31e80
+0xffff9ac576f33d00
+0xffff9ac576f35b80
+0xffff9ac611375b80
+0xffff9ac611370000
+0xffff9ac611371e80
+0xffff9ac611373d00
+0xffff9ac6090edb80
+0xffff9ac6090e8000
+0xffff9ac6090e9e80
+0xffff9ac6090ebd00
+0xffff9ac60cbe8000
+0xffff9ac60cbe9e80
+0xffff9ac60cbebd00
+0xffff9ac60cbedb80
+0xffff9ac64ada1e80
+0xffff9ac64ada3d00
+0xffff9ac64ada0000
+0xffff9ac610951e80
+0xffff9ac610953d00
+0xffff9ac610950000
+0xffff9ac610a50000
+0xffff9ac610a51e80
+0xffff9ac610a53d00
+0xffff9ac610a55b80
+0xffff9ac60e745b80
+0xffff9ac60e740000
+0xffff9ac60e741e80
+0xffff9ac60e743d00
+0xffff9ac64a400000
+0xffff9ac64a403d00
+0xffff9ac64a405b80
+0xffff9ac60e363d00
+0xffff9ac60e365b80
+0xffff9ac60e360000
+0xffff9ac60e361e80
+0xffff9ac60d678000
+0xffff9ac60d679e80
+0xffff9ac60d67bd00
+0xffff9ac60d67db80
+0xffff9ac60d339e80
+0xffff9ac60d33bd00
+0xffff9ac60d33db80
+0xffff9ac611921e80
+0xffff9ac611923d00
+0xffff9ac611925b80
+0xffff9ac611920000
+0xffff9ac611c23d00
+0xffff9ac611c25b80
+0xffff9ac611c20000
+0xffff9ac611c21e80
+0xffff9ac611a69e80
+0xffff9ac611a6bd00
+0xffff9ac611a6db80
+0xffff9ac611a68000
+0xffff9ac611f49e80
+0xffff9ac611f4bd00
+0xffff9ac611f4db80
+0xffff9ac611f48000
+0xffff9ac610ab9e80
+0xffff9ac610abbd00
+0xffff9ac610abdb80
+0xffff9ac610ab8000
+0xffff9ac610aa1e80
+0xffff9ac610aa3d00
+0xffff9ac610aa5b80
+0xffff9ac610aa0000
+0xffff9ac612e30000
+0xffff9ac612e31e80
+0xffff9ac612e33d00
+0xffff9ac612e35b80
+0xffff9ac612d65b80
+0xffff9ac612d60000
+0xffff9ac612d61e80
+0xffff9ac612d63d00
+0xffff9ac650a0bd00
+0xffff9ac650a0db80
+0xffff9ac650a08000
+0xffff9ac650a09e80
+0xffff9ac654fbbd00
+0xffff9ac654fbdb80
+0xffff9ac654fb8000
+0xffff9ac654fb9e80
+0xffff9ac650a53d00
+0xffff9ac650a55b80
+0xffff9ac650a50000
+0xffff9ac650a51e80
+0xffff9ac65b1c0000
+0xffff9ac65b1c1e80
+0xffff9ac65b1c3d00
+0xffff9ac65b1c5b80
+0xffff9ac652588000
+0xffff9ac652589e80
+0xffff9ac65258bd00
+0xffff9ac611710000
+0xffff9ac611713d00
+0xffff9ac618a31e80
+0xffff9ac618a30000
+0xffff9ac618a35b80
+0xffff9ac618a33d00
+0xffff9ac5e3ef1e80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  futex_wait_queue_me+0xbb
+                  futex_wait+0x105
+                  do_futex+0x157
+                  __do_sys_futex (inlined)
+                  __se_sys_futex (inlined)
+                  __x64_sys_futex+0x13f
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac65f35db80 INTERRUPTIBLE   
+0xffff9ac6607d0000
+0xffff9ac65f358000
+0xffff9ac6607d1e80
+0xffff9ac6607ddb80
+0xffff9ac6607b0000
+0xffff9ac65f360000
+0xffff9ac6607b5b80
+0xffff9ac65927db80
+0xffff9ac658ed8000
+0xffff9ac659279e80
+0xffff9ac659278000
+0xffff9ac658edbd00
+0xffff9ac659261e80
+0xffff9ac65927bd00
+0xffff9ac659265b80
+0xffff9ac658c35b80
+0xffff9ac659260000
+0xffff9ac658c31e80
+0xffff9ac6591ebd00
+0xffff9ac659263d00
+0xffff9ac658e09e80
+0xffff9ac6588a1e80
+0xffff9ac6588a5b80
+0xffff9ac658e0db80
+0xffff9ac658e08000
+0xffff9ac658e0bd00
+0xffff9ac6588a0000
+0xffff9ac6588a3d00
+0xffff9ac659258000
+0xffff9ac65925db80
+0xffff9ac658c9bd00
+0xffff9ac658eddb80
+0xffff9ac658ed9e80
+0xffff9ac658c98000
+0xffff9ac601bf8000
+0xffff9ac601bfdb80
+0xffff9ac601bf9e80
+0xffff9ac5fc715b80
+0xffff9ac6607abd00
+0xffff9ac613a29e80
+0xffff9ac5fc710000
+0xffff9ac613a2db80
+0xffff9ac5fbe43d00
+0xffff9ac660601e80
+0xffff9ac613a2bd00
+0xffff9ac5ff678000
+0xffff9ac5ff679e80
+0xffff9ac5fbef9e80
+0xffff9ac5ff67db80
+0xffff9ac5fbefbd00
+0xffff9ac5fbefdb80
+0xffff9ac660798000
+0xffff9ac5fef10000
+0xffff9ac5fbcf5b80
+0xffff9ac5fbcf1e80
+0xffff9ac5fef11e80
+0xffff9ac652780000
+0xffff9ac5fcb2db80
+0xffff9ac635f45b80
+0xffff9ac5fbcf0000
+0xffff9ac601bfbd00
+0xffff9ac658688000
+0xffff9ac65868bd00
+0xffff9ac6607e9e80
+0xffff9ac64aed3d00
+0xffff9ac65f361e80
+0xffff9ac6607d3d00
+0xffff9ac60d835b80
+0xffff9ac612d31e80
+0xffff9ac612d33d00
+0xffff9ac5fbe45b80
+0xffff9ac5c44c9e80
+0xffff9ac612d99e80
+0xffff9ac612d9bd00
+0xffff9ac60d2bbd00
+0xffff9ac612d9db80
+0xffff9ac60d2b9e80
+0xffff9ac60d2b8000
+0xffff9ac612d98000
+0xffff9ac6607f9e80
+0xffff9ac652781e80
+0xffff9ac660743d00
+0xffff9ac66065db80
+0xffff9ac60d830000
+0xffff9ac58e693d00
+0xffff9ac58e691e80
+0xffff9ac58e695b80
+0xffff9ac58e690000
+0xffff9ac60080bd00
+0xffff9ac6148e0000
+0xffff9ac6148e3d00
+0xffff9ac5e3063d00
+0xffff9ac614809e80
+0xffff9ac614808000
+0xffff9ac61480bd00
+0xffff9ac61480db80
+0xffff9ac4a6525b80
+0xffff9ac5fc713d00
+0xffff9ac5fc711e80
+0xffff9ac5fbe41e80
+0xffff9ac5e6fc0000
+0xffff9ac5e6fc5b80
+0xffff9ac5e6fc1e80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  taskq_thread+0x33b
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6605e5b80 INTERRUPTIBLE   
+0xffff9ac6607a9e80
+0xffff9ac6607bdb80
+0xffff9ac6607a3d00
+0xffff9ac652785b80
+0xffff9ac6607adb80
+0xffff9ac6525c9e80
+0xffff9ac621200000
+0xffff9ac61c899e80
+0xffff9ac613d5bd00
+0xffff9ac613530000
+0xffff9ac60f241e80
+0xffff9ac5e0c8bd00
+0xffff9ac5fc289e80
+0xffff9ac612738000
+0xffff9ac61273bd00
+0xffff9ac6007fdb80
+0xffff9ac5fd001e80
+0xffff9ac5fd005b80
+0xffff9ac5fc28bd00
+0xffff9ac5fc28db80
+0xffff9ac5fc288000
+0xffff9ac61276bd00
+0xffff9ac612769e80
+0xffff9ac61276db80
+0xffff9ac612768000
+0xffff9ac549b18000
+0xffff9ac549b19e80
+0xffff9ac549b1db80
+0xffff9ac549b1bd00
+0xffff9ac549695b80
+0xffff9ac549693d00
+0xffff9ac549690000
+0xffff9ac553d29e80
+0xffff9ac6123e8000
+0xffff9ac6136c3d00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x3bd
+                  do_epoll_wait+0xb8
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac613483d00 INTERRUPTIBLE   
+0xffff9ac645448000
+0xffff9ac611bf9e80
+0xffff9ac611bfdb80
+0xffff9ac611bfbd00
+0xffff9ac611bf8000
+0xffff9ac613189e80
+0xffff9ac61318db80
+0xffff9ac61318bd00
+0xffff9ac613188000
+0xffff9ac613211e80
+0xffff9ac613215b80
+0xffff9ac613213d00
+0xffff9ac613210000
+0xffff9ac613191e80
+0xffff9ac613195b80
+0xffff9ac613193d00
+0xffff9ac611f18000
+0xffff9ac611f19e80
+0xffff9ac611f1db80
+0xffff9ac611f1bd00
+0xffff9ac611783d00
+0xffff9ac611430000
+0xffff9ac611431e80
+0xffff9ac5558c5b80
+0xffff9ac5459edb80
+0xffff9ac60aa81e80
+0xffff9ac5f17e3d00
+0xffff9ac6136bdb80
+0xffff9ac5b1c18000
+0xffff9ac5b753db80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  do_wait+0x1c7
+                  kernel_wait4+0xaf
+                  __do_sys_wait4+0x85
+                  __se_sys_wait4 (inlined)
+                  __x64_sys_wait4+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6605e3d00 IDLE            
+0xffff9ac6605e1e80
+0xffff9ac6605f8000
+0xffff9ac66065bd00
+0xffff9ac660663d00
+0xffff9ac6607f8000
+0xffff9ac65fc00000
+0xffff9ac6607fbd00
+0xffff9ac65fc03d00
+0xffff9ac65fc01e80
+0xffff9ac6607fdb80
+0xffff9ac6607f0000
+0xffff9ac6607f1e80
+0xffff9ac6607e8000
+0xffff9ac6607f5b80
+0xffff9ac6607e0000
+0xffff9ac6607e3d00
+0xffff9ac65f35bd00
+0xffff9ac6607d9e80
+0xffff9ac6607d8000
+0xffff9ac6607a5b80
+0xffff9ac64aed5b80
+0xffff9ac64aed0000
+0xffff9ac613a28000
+0xffff9ac5fcb28000
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  rescuer_thread+0x2f4
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac64c889e80 INTERRUPTIBLE   
+0xffff9ac6131f0000
+0xffff9ac611771e80
+0xffff9ac6114c9e80
+0xffff9ac611770000
+0xffff9ac611153d00
+0xffff9ac611749e80
+0xffff9ac611425b80
+0xffff9ac6050ebd00
+0xffff9ac6050edb80
+0xffff9ac611ae1e80
+0xffff9ac611780000
+0xffff9ac6131b5b80
+0xffff9ac611151e80
+0xffff9ac64544db80
+0xffff9ac611423d00
+0xffff9ac611755b80
+0xffff9ac611753d00
+0xffff9ac6131f1e80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  do_nanosleep+0x87
+                  hrtimer_nanosleep+0xc2
+                  common_nsleep+0x1c
+                  __do_sys_clock_nanosleep (inlined)
+                  __se_sys_clock_nanosleep (inlined)
+                  __x64_sys_clock_nanosleep+0xc6
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac613d5db80 INTERRUPTIBLE   
+0xffff9ac5a7d20000
+0xffff9ac6112d8000
+0xffff9ac6112ddb80
+0xffff9ac6112dbd00
+0xffff9ac6113edb80
+0xffff9ac6113e8000
+0xffff9ac612d03d00
+0xffff9ac612d01e80
+0xffff9ac61772bd00
+0xffff9ac4d324bd00
+0xffff9ac6478a9e80
+0xffff9ac6478a8000
+0xffff9ac61772db80
+0xffff9ac612d05b80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3ee
+                  __do_sys_ppoll (inlined)
+                  __se_sys_ppoll (inlined)
+                  __x64_sys_ppoll+0xa8
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6605f9e80 IDLE            
+0xffff9ac6605fdb80
+0xffff9ac660658000
+0xffff9ac6607e5b80
+0xffff9ac6607d5b80
+0xffff9ac65925bd00
+0xffff9ac659259e80
+0xffff9ac65f363d00
+0xffff9ac6525cdb80
+0xffff9ac5fbe40000
+0xffff9ac612d30000
+0xffff9ac612d35b80
+0xffff9ac5c44cdb80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  worker_thread+0xcf
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6589f8000 INTERRUPTIBLE   
+0xffff9ac6589fbd00
+0xffff9ac6591edb80
+0xffff9ac6591e8000
+0xffff9ac5bb82bd00
+0xffff9ac5bb829e80
+0xffff9ac5c44c8000
+0xffff9ac5c44cbd00
+0xffff9ac5ad735b80
+0xffff9ac5ad730000
+0xffff9ac5ad733d00
+0xffff9ac5ad731e80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  zthr_procedure+0x45
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac658c99e80 INTERRUPTIBLE   
+0xffff9ac65f365b80
+0xffff9ac647b38000
+0xffff9ac645d3db80
+0xffff9ac64a525b80
+0xffff9ac64a521e80
+0xffff9ac635f41e80
+0xffff9ac5fc9a3d00
+0xffff9ac5e0c8db80
+0xffff9ac544ad8000
+0xffff9ac544adbd00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3ee
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0x3b
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60e2fbd00 UNINTERRUPTIBLE 
+0xffff9ac65258db80
+0xffff9ac6113ebd00
+0xffff9ac6113e9e80
+0xffff9ac6085b9e80
+0xffff9ac617729e80
+0xffff9ac6085b8000
+0xffff9ac6478abd00
+0xffff9ac6478adb80
+0xffff9ac617728000
+0xffff9ac6085bdb80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  io_schedule_timeout+0x1e
+                  __cv_timedwait_common+0x15e
+                  __cv_timedwait_io+0x19
+                  zio_wait+0x116
+                  dmu_tx_count_write+0x139
+                  dmu_tx_hold_write_by_dnode+0x3b
+                  zfs_write+0x412
+                  zpl_iter_write+0xe6
+                  call_write_iter (inlined)
+                  new_sync_write+0x125
+                  __vfs_write+0x29
+                  vfs_write (inlined)
+                  vfs_write+0xb9
+                  ksys_pwrite64+0x6d
+                  __do_sys_pwrite64 (inlined)
+                  __se_sys_pwrite64 (inlined)
+                  __x64_sys_pwrite64+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6607b9e80 INTERRUPTIBLE   
+0xffff9ac611775b80
+0xffff9ac611ae0000
+0xffff9ac611155b80
+0xffff9ac6007f8000
+0xffff9ac5ff91db80
+0xffff9ac5ff91bd00
+0xffff9ac60aa85b80
+0xffff9ac5f17e1e80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x579
+                  core_sys_select+0x1b1
+                  kern_select+0xb8
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x25
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6123e9e80 INTERRUPTIBLE   
+0xffff9ac6114cbd00
+0xffff9ac6131b3d00
+0xffff9ac6131b0000
+0xffff9ac613190000
+0xffff9ac6131f5b80
+0xffff9ac611750000
+0xffff9ac611ae5b80
+0xffff9ac611ae3d00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  sigsuspend+0x41
+                  __do_sys_rt_sigsuspend (inlined)
+                  __se_sys_rt_sigsuspend (inlined)
+                  __x64_sys_rt_sigsuspend+0x43
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64adb1e80 INTERRUPTIBLE   
+0xffff9ac5ff919e80
+0xffff9ac5ff918000
+0xffff9ac5459e8000
+0xffff9ac5459ebd00
+0xffff9ac5f17e5b80
+0xffff9ac5f17e0000
+0xffff9ac60a58db80
+0xffff9ac60a588000
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  pipe_wait+0x6f
+                  pipe_read+0x20b
+                  call_read_iter (inlined)
+                  new_sync_read+0x122
+                  __vfs_read+0x29
+                  vfs_read (inlined)
+                  vfs_read+0xab
+                  ksys_read+0x67
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6607a1e80 INTERRUPTIBLE   
+0xffff9ac652783d00
+0xffff9ac6007f9e80
+0xffff9ac6007fbd00
+0xffff9ac613d59e80
+0xffff9ac613d58000
+0xffff9ac61273db80
+0xffff9ac5cc070000
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x3bd
+                  do_epoll_wait+0xb8
+                  __do_sys_epoll_wait (inlined)
+                  __se_sys_epoll_wait (inlined)
+                  __x64_sys_epoll_wait+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac65868db80 INTERRUPTIBLE   
+0xffff9ac658689e80
+0xffff9ac64c88db80
+0xffff9ac6134d3d00
+0xffff9ac6607edb80
+0xffff9ac5e6fc3d00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x579
+                  core_sys_select+0x1b1
+                  kern_select+0xb8
+                  __do_sys_select (inlined)
+                  __se_sys_select (inlined)
+                  __x64_sys_select+0x25
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac660605b80 INTERRUPTIBLE   
+0xffff9ac660603d00
+0xffff9ac66064bd00
+0xffff9ac660649e80
+0xffff9ac66064db80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  smpboot_thread_fn+0x117
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac64ada5b80 RUNNING         
+0xffff9ac610955b80
+0xffff9ac64a401e80
+0xffff9ac60d338000
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  futex_wait_queue_me+0xbb
+                  futex_wait+0x105
+                  do_futex+0x157
+                  __do_sys_futex (inlined)
+                  __se_sys_futex (inlined)
+                  __x64_sys_futex+0x13f
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6589f9e80 INTERRUPTIBLE   
+0xffff9ac5bb828000
+0xffff9ac5e3060000
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x119
+                  cv_timedwait_hires_common+0x1f
+                  cv_timedwait_idle_hires+0x66
+                  mmp_thread+0x2be
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac64cba9e80 INTERRUPTIBLE   
+0xffff9ac6114cdb80
+0xffff9ac611420000
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  __x64_sys_pause+0x27
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac61c89bd00 INTERRUPTIBLE   
+0xffff9ac611723d00
+0xffff9ac612623d00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  ep_poll+0x3bd
+                  do_epoll_wait+0xb8
+                  __do_sys_epoll_pwait (inlined)
+                  __se_sys_epoll_pwait (inlined)
+                  __x64_sys_epoll_pwait+0x4c
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60f245b80 INTERRUPTIBLE   
+0xffff9ac5d1850000
+0xffff9ac5cc071e80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x271
+                  inet_accept+0x45
+                  __sys_accept4+0x109
+                  __do_sys_accept (inlined)
+                  __se_sys_accept (inlined)
+                  __x64_sys_accept+0x1c
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6589fdb80 INTERRUPTIBLE   
+0xffff9ac5fcb2bd00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  txg_thread_wait+0x2e
+                  txg_quiesce_thread+0x137
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607a8000 INTERRUPTIBLE   
+0xffff9ac66079bd00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_poll (inlined)
+                  do_sys_poll+0x3ee
+                  __do_sys_poll (inlined)
+                  __se_sys_poll (inlined)
+                  __x64_sys_poll+0xa5
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64c88bd00 INTERRUPTIBLE   
+0xffff9ac4a6523d00
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  freezable_schedule_hrtimeout_range (inlined)
+                  do_sigtimedwait+0x17f
+                  __do_sys_rt_sigtimedwait (inlined)
+                  __se_sys_rt_sigtimedwait (inlined)
+                  __x64_sys_rt_sigtimedwait+0x71
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60d2bdb80 INTERRUPTIBLE   
+0xffff9ac6607e1e80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_sig+0x15
+                  bqueue_dequeue+0x73
+                  vdev_object_store_send_thread+0x37
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6148e1e80 RUNNING         
+0xffff9ac6148e5b80
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  taskq_thread+0x33b
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6605e0000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kthreadd+0x2cb
+                  ret_from_fork+0x1f
+
+0xffff9ac660600000 RUNNING         
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  rcu_gp_kthread+0x8e2
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660659e80 RUNNING         
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  smpboot_thread_fn+0x117
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660661e80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  devtmpfsd+0x2df
+                  devtmpfsd+0x57
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660665b80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  rcu_tasks_kthread+0xbc
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660740000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  kauditd_thread+0x1c6
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660660000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  schedule_timeout_interruptible+0x1f
+                  watchdog+0x78
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660741e80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  oom_reaper+0x172
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660745b80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  kcompactd+0x175
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac660799e80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  freezable_schedule (inlined)
+                  ksm_scan_thread+0x752
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607a0000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  freezable_schedule_timeout (inlined)
+                  khugepaged_wait_work (inlined)
+                  khugepaged+0x3a9
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac65fc05b80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kthread_worker_fn+0x12b
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607f3d00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kswapd_try_to_sleep (inlined)
+                  kswapd+0x36c
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac65f359e80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x119
+                  cv_timedwait_hires_common+0x56
+                  cv_timedwait_idle_hires+0x66
+                  zthr_procedure+0x96
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607b8000 UNINTERRUPTIBLE 
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  schedule_timeout_uninterruptible+0x1f
+                  arc_reap_cb+0x26
+                  zthr_procedure+0x130
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607b3d00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0x97
+                  schedule_hrtimeout_range+0x13
+                  __cv_timedwait_hires+0x119
+                  cv_timedwait_hires_common+0x56
+                  cv_timedwait_idle_hires+0x66
+                  dbuf_evict_thread+0x50
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6607ebd00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  __cv_timedwait_common+0xf3
+                  __cv_timedwait_idle+0x59
+                  l2arc_feed_thread+0x64
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac658c30000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  __cv_timedwait_common+0xf3
+                  __cv_timedwait_idle+0x59
+                  txg_thread_wait+0x27
+                  txg_sync_thread+0xfd
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac6525cbd00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  __skb_wait_for_more_packets+0x103
+                  __skb_recv_datagram+0x67
+                  skb_recv_datagram+0x3b
+                  unix_accept+0x91
+                  __sys_accept4+0x109
+                  __do_sys_accept4 (inlined)
+                  __se_sys_accept4 (inlined)
+                  __x64_sys_accept4+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6525c8000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_sig+0x15
+                  zfs_zevent_wait+0x3f
+                  zfs_ioc_events_next+0x6f
+                  zfsdev_ioctl_common+0x5df
+                  zfsdev_ioctl+0x57
+                  vfs_ioctl (inlined)
+                  file_ioctl (inlined)
+                  do_vfs_ioctl+0x407
+                  ksys_ioctl+0x67
+                  __do_sys_ioctl (inlined)
+                  __se_sys_ioctl (inlined)
+                  __x64_sys_ioctl+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64cbadb80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  __skb_wait_for_more_packets+0x103
+                  __skb_recv_datagram+0x67
+                  skb_recv_datagram+0x3b
+                  netlink_recvmsg+0x54
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x70
+                  ____sys_recvmsg+0xa4
+                  ___sys_recvmsg+0x7c
+                  __sys_recvmsg+0x59
+                  __do_sys_recvmsg (inlined)
+                  __se_sys_recvmsg (inlined)
+                  __x64_sys_recvmsg+0x1f
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac64bfbbd00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  do_syslog+0x846
+                  do_syslog+0x39
+                  kmsg_read+0x43
+                  proc_reg_read+0x43
+                  __vfs_read+0x1b
+                  vfs_read (inlined)
+                  vfs_read+0xab
+                  ksys_read+0x67
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5fcb29e80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  kjournald2+0x222
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5fbef8000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  inet_csk_wait_for_connect (inlined)
+                  inet_csk_accept+0x271
+                  inet_accept+0x45
+                  kernel_accept+0x59
+                  iscsit_accept_np+0x38
+                  __iscsi_target_login_thread+0xe7
+                  iscsi_target_login_thread+0x24
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5559c0000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  eventfd_read+0x17d
+                  __vfs_read+0x1b
+                  vfs_read (inlined)
+                  vfs_read+0xab
+                  ksys_read+0x67
+                  __do_sys_read (inlined)
+                  __se_sys_read (inlined)
+                  __x64_sys_read+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac6605fbd00 UNINTERRUPTIBLE 
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_preempt_disabled+0xe
+                  __mutex_lock_common (inlined)
+                  __mutex_lock+0x172
+                  __mutex_lock_slowpath+0x13
+                  mutex_lock+0x2e
+                  free_from_removing_vdev+0x5d
+                  metaslab_free_impl+0xd8
+                  metaslab_free_dva+0x5e
+                  metaslab_free+0x180
+                  zio_free_sync+0xea
+                  zio_free+0xb0
+                  dsl_free+0x11
+                  dsl_dataset_block_kill+0x2a0
+                  dbuf_write_done+0x15e
+                  arc_write_done+0x25a
+                  zio_done+0x3ae
+                  __zio_execute (inlined)
+                  zio_execute+0x92
+                  taskq_thread+0x220
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5bb82db80 UNINTERRUPTIBLE 
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x8a
+                  io_schedule_timeout+0x1e
+                  __cv_timedwait_common+0x15e
+                  __cv_timedwait_io+0x19
+                  zio_wait+0x116
+                  dsl_pool_sync+0xbb
+                  spa_sync_iterate_to_convergence+0xf1
+                  spa_sync+0x31c
+                  txg_sync_thread+0x22d
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac612d00000 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_hrtimeout_range_clock+0xf9
+                  schedule_hrtimeout_range+0x13
+                  poll_schedule_timeout+0x46
+                  do_select+0x579
+                  core_sys_select+0x1b1
+                  do_pselect+0xaf
+                  __do_sys_pselect6 (inlined)
+                  __se_sys_pselect6 (inlined)
+                  __x64_sys_pselect6+0x6b
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5a7d23d00 RUNNING         
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  exit_to_usermode_loop+0x82
+                  prepare_exit_to_usermode+0x77
+                  common_interrupt+0x34
+                  0x7fc25ecfa733+0x0
+
+0xffff9ac5a7d21e80 RUNNING         
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  exit_to_usermode_loop+0x82
+                  prepare_exit_to_usermode+0x77
+                  common_interrupt+0x34
+                  0x7fc25f204c0d+0x0
+
+0xffff9ac5a7d25b80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  freezable_schedule_timeout (inlined)
+                  unix_stream_data_wait (inlined)
+                  unix_stream_read_generic+0x656
+                  unix_stream_recvmsg+0x51
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x70
+                  __sys_recvfrom+0x19e
+                  __do_sys_recvfrom (inlined)
+                  __se_sys_recvfrom (inlined)
+                  __x64_sys_recvfrom+0x29
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac60d833d00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  freezable_schedule_timeout (inlined)
+                  unix_stream_data_wait (inlined)
+                  unix_stream_read_generic+0x656
+                  unix_stream_recvmsg+0x51
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x70
+                  kernel_recvmsg+0x54
+                  ksock_receive+0x14
+                  zfs_object_store_receive+0x87
+                  agent_receive_all+0x8b
+                  agent_reader+0x43
+                  vdev_object_store_receive_thread+0x95
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac60d831e80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_sig+0x15
+                  bqueue_dequeue+0x73
+                  vdev_object_store_send_thread+0xb8
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5e3061e80 RUNNING         
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  txg_thread_wait+0x2e
+                  txg_quiesce_thread+0x137
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5e3065b80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  cv_wait_common+0x11e
+                  __cv_wait_idle+0x50
+                  txg_thread_wait+0x2e
+                  txg_sync_thread+0x182
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac60e2f8000 RUNNING         
+                  dbuf_find+0xae
+                  dbuf_hold_impl+0x72
+                  dbuf_hold_level+0x32
+                  dbuf_hold+0x16
+                  dmu_buf_hold_array_by_dnode+0x151
+                  dmu_write_uio_dnode+0x4c
+                  dmu_write_uio_dbuf+0x4f
+                  zfs_write+0x4d1
+                  zpl_iter_write+0xe6
+                  call_write_iter (inlined)
+                  new_sync_write+0x125
+                  __vfs_write+0x29
+                  vfs_write (inlined)
+                  vfs_write+0xb9
+                  ksys_pwrite64+0x6d
+                  __do_sys_pwrite64 (inlined)
+                  __se_sys_pwrite64 (inlined)
+                  __x64_sys_pwrite64+0x1e
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5fef15b80 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  iscsi_target_tx_thread+0x1d2
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5fef13d00 INTERRUPTIBLE   
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  schedule+0x42
+                  schedule_timeout+0x10e
+                  wait_woken+0x48
+                  sk_wait_data+0x123
+                  tcp_recvmsg+0x5a7
+                  inet_recvmsg+0x5e
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg_nosec (inlined)
+                  sock_recvmsg+0x69
+                  iscsit_do_rx_data+0x90
+                  rx_data+0x5f
+                  iscsit_get_rx_pdu+0xd2
+                  iscsi_target_rx_thread+0x94
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+0xffff9ac5b7539e80 RUNNING         
+                  crash_setup_regs (inlined)
+                  __crash_kexec+0x9d
+                  panic+0x11d
+                  sysrq_handle_crash+0x15
+                  __handle_sysrq+0x48
+                  write_sysrq_trigger+0x28
+                  proc_reg_write+0x43
+                  __vfs_write+0x1b
+                  vfs_write (inlined)
+                  vfs_write+0xb9
+                  ksys_write+0x67
+                  __do_sys_write (inlined)
+                  __se_sys_write (inlined)
+                  __x64_sys_write+0x1a
+                  do_syscall_64+0x57
+                  entry_SYSCALL_64+0x94
+
+0xffff9ac5fbcf3d00 RUNNING         
+                  context_switch (inlined)
+                  __schedule+0x2de
+                  preempt_schedule_common+0x18
+                  _cond_resched+0x22
+                  slab_pre_alloc_hook (inlined)
+                  slab_alloc_node (inlined)
+                  slab_alloc (inlined)
+                  kmem_cache_alloc+0x1ea
+                  spl_kmem_cache_alloc+0x3b
+                  zfs_btree_leaf_alloc+0x39
+                  zfs_btree_insert_into_leaf+0x1d2
+                  zfs_btree_add_idx+0x15f
+                  range_tree_add_impl+0x49d
+                  range_tree_add+0x11
+                  space_map_load_callback+0x59
+                  space_map_iterate+0x20f
+                  space_map_load_length+0x61
+                  space_map_load+0x2e
+                  spa_vdev_remove_thread+0x18f
+                  thread_generic_wrapper+0x83
+                  kthread+0x104
+                  ret_from_fork+0x1f
+
+@#$ EXIT CODE $#@
+0

--- a/tests/integration/test_linux_generic.py
+++ b/tests/integration/test_linux_generic.py
@@ -88,8 +88,8 @@ POS_CMDS = [
     'slabs | filter \'obj.name == "UNIX"\' | slub_cache | count',
 
     # stacks - disabled due to second ref dump issues
-    # "stacks",
-    # "stacks -a",
+    "stacks",
+    "stacks -a",
     "stacks -m zfs",
     "stacks -c spa_sync",
     "stacks -m zfs -c spa_sync",


### PR DESCRIPTION
Enable stacks and stacks -a integration cases by adding regression outputs for both reference dumps so the linux generic suite can validate them.