### PR TITLE
ci: update GitHub workflows for codecov and release improvements

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,67 @@
+#
+# Cut Release workflow - manually create and push a version tag
+#
+# This workflow:
+# 1. Validates the version format
+# 2. Checks if the tag already exists
+# 3. Creates and pushes the tag
+#
+# After running this, the Release workflow will automatically trigger.
+#
+name: Cut Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., v0.2.0 or v0.2.0-beta1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  cut-release:
+    name: Cut Release
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+            echo "Error: Version must be in format v0.0.0 or v0.0.0-suffix"
+            echo "Got: $VERSION"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Check if tag already exists
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Error: Tag $VERSION already exists"
+            exit 1
+          fi
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+
+      - name: Summary
+        run: |
+          echo "## Tag $VERSION created!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The **Release** workflow should now trigger automatically." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "You can monitor it at [Actions → Release](/${{ github.repository }}/actions/workflows/release.yml)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,13 @@ jobs:
       - run: python3 -m pip install pytest pytest-cov
       - run: ./.github/scripts/install-drgn.sh
       - run: pytest -v --cov sdb --cov-report xml tests/unit
-      - uses: codecov/codecov-action@v4
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          verbose: true
   #
   # Verify "pytest" runs successfully on integration tests with crash dumps.
   #
@@ -94,9 +98,13 @@ jobs:
       - run: ./.github/scripts/extract-dump.sh dump.201912060006.tar.lzma
       - run: ./.github/scripts/extract-dump.sh dump.202303131823.tar.gz
       - run: pytest -v --cov sdb --cov-report xml tests/integration
-      - uses: codecov/codecov-action@v4
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          verbose: true
   #
   # Verify "yapf" runs successfully.
   #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Release workflow - triggered on version tag push (e.g., v0.2.0)
+# Release workflow - triggered on version tag push (e.g., v0.2.0) or manually
 #
 # This workflow:
 # 1. Runs all CI checks (lint, type-check, tests)
@@ -12,7 +12,18 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'  # Allow pre-release tags like v0.2.0-beta1
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.2.0)'
+        required: true
+        type: string
+
+env:
+  # Use input tag for workflow_dispatch, or ref_name for tag push
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 # Required for PyPI Trusted Publishing (OIDC)
 permissions:
@@ -27,6 +38,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -42,6 +55,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -57,6 +72,8 @@ jobs:
         python-version: ['3.10', '3.12']
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -73,6 +90,8 @@ jobs:
       AWS_DEFAULT_REGION: 'us-west-2'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -93,6 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0  # Required for setuptools_scm to get version from tags
       - uses: actions/setup-python@v5
         with:
@@ -134,19 +154,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0  # Required for generating release notes
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
-      - name: Get version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: sdb ${{ steps.version.outputs.VERSION }}
-          generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create '${{ env.RELEASE_TAG }}' \
+            --title 'sdb ${{ env.RELEASE_TAG }}' \
+            --generate-notes \
+            dist/*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 <p align="center">
     <a href="https://github.com/sdimitro/sdb/actions/workflows/main.yml"><img src="https://github.com/sdimitro/sdb/actions/workflows/main.yml/badge.svg" alt="CI"></a>
+    <a href="https://codecov.io/gh/sdimitro/sdb"><img src="https://codecov.io/gh/sdimitro/sdb/graph/badge.svg" alt="Codecov"></a>
     <a href="https://pypi.org/project/sdb-debugger/"><img src="https://img.shields.io/pypi/v/sdb-debugger" alt="PyPI"></a>
     <a href="https://pypi.org/project/sdb-debugger/"><img src="https://img.shields.io/pypi/pyversions/sdb-debugger" alt="Python Versions"></a>
     <a href="https://github.com/sdimitro/sdb/blob/master/LICENSE"><img src="https://img.shields.io/github/license/sdimitro/sdb" alt="License"></a>


### PR DESCRIPTION
- Upgrade codecov action from v4 to v5 with explicit file paths
  and verbose output to fix codecov integration
- Add cut-release.yml workflow for manual tag creation from UI
- Update release.yml to support both tag pushes and workflow_dispatch
  for manual releases, with proper pre-release tag support

https://claude.ai/code/session_01VpQtQjga9ckULxmB3ubyEK