### PR TITLE
feat: add plugin loader and library API for external integrations

### DIFF
--- a/sdb/__init__.py
+++ b/sdb/__init__.py
@@ -22,6 +22,10 @@ can be used to implement commands for SDB and alternative
 CLI/consumer implementations.
 """
 
+from typing import Callable, List, Optional
+
+import drgn
+
 # Version is set by setuptools_scm from git tags
 try:
     from sdb._version import version as __version__
@@ -82,6 +86,7 @@ from sdb.command import (
     get_registered_commands,
     register_commands,
 )
+from sdb.loader import load_external_commands
 from sdb.pipeline import execute_pipeline, get_first_type, invoke
 
 __all__ = [
@@ -99,12 +104,14 @@ __all__ = [
     'InputHandler',
     'Kernel',
     'Library',
+    'load_external_commands',
     'Locator',
     'Module',
     'ParserError',
     'PrettyPrinter',
     'Runtime',
     'SingleInputCommand',
+    'start',
     'SymbolNotFoundError',
     'Userland',
     'Walk',
@@ -138,3 +145,88 @@ __all__ = [
 # above, so we must be sure to import all of the commands last.
 #
 import sdb.commands  # noqa: F401
+
+
+def start(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    prog: drgn.Program,
+    command_paths: Optional[List[str]] = None,
+    prompt: str = "sdb> ",
+    pre_cmd_hook: Optional[Callable[[], None]] = None,
+    eval_cmd: Optional[str] = None,
+    history_file: str = "~/.sdb_history",
+) -> None:
+    """
+    High-level entry point for using sdb as a library.
+
+    This function accepts a pre-configured ``drgn.Program`` (e.g. one
+    created by GhostWire with TCP-backed memory segments) and starts
+    the sdb REPL.  It is the primary integration point for external
+    tools that want to drive sdb programmatically.
+
+    Args:
+        prog: A fully-initialised drgn.Program.
+        command_paths: Optional list of filesystem paths (files or
+            directories) from which to load additional sdb commands.
+        prompt: REPL prompt string (or an object whose ``__str__``
+            is called each time the prompt is displayed).
+        pre_cmd_hook: Optional callable invoked before every command
+            evaluation (e.g. to bump a transport cache generation).
+        eval_cmd: If provided, evaluate this single command and return
+            instead of starting the interactive REPL.
+        history_file: Path used for readline history persistence.
+    """
+    _start_impl(prog, command_paths, prompt, pre_cmd_hook, eval_cmd,
+                history_file)
+
+
+def _start_impl(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    prog: drgn.Program,
+    command_paths: Optional[List[str]],
+    prompt: str,
+    pre_cmd_hook: Optional[Callable[[], None]],
+    eval_cmd: Optional[str],
+    history_file: str,
+) -> None:
+    import os
+    import sys
+
+    import sdb.target as sdb_target
+    from sdb.internal.repl import REPL
+    from sdb.mdb_compat import set_mdb_compat_enabled
+
+    set_mdb_compat_enabled(True)
+
+    sdb_target.set_prog(prog)
+
+    try:
+        sdb_target.set_thread(prog.crashed_thread().object)
+    except (ValueError, StopIteration):
+        try:
+            sdb_target.set_thread(next(prog.threads()).object)
+        except StopIteration:
+            sdb_target.set_thread(0)
+    sdb_target.set_frame(-1)
+
+    if command_paths:
+        for path in command_paths:
+            load_external_commands(path)
+
+    env_paths = os.environ.get("SDB_COMMANDS_PATH", "")
+    if env_paths:
+        for p in env_paths.split(":"):
+            if p.strip():
+                load_external_commands(p.strip())
+
+    register_commands()
+
+    repl = REPL(prog,
+                list(get_registered_commands().keys()),
+                prompt=prompt,
+                pre_cmd_hook=pre_cmd_hook)
+    repl.enable_history(os.getenv("SDB_HISTORY_FILE", history_file))
+
+    if eval_cmd:
+        exit_code = repl.eval_cmd(eval_cmd)
+        sys.exit(exit_code)
+    else:
+        repl.start_session()

--- a/sdb/internal/cli.py
+++ b/sdb/internal/cli.py
@@ -118,6 +118,14 @@ def parse_arguments() -> argparse.Namespace:
         action="store_false",
         help="disable mdb compatibility syntax (symbol::cmd)",
     )
+    parser.add_argument(
+        "--load-commands",
+        metavar="PATH",
+        default=[],
+        action="append",
+        help="load external sdb commands from PATH (file or directory);"
+        " this option may be given more than once",
+    )
 
     # Session recording and replay
     session_group = parser.add_argument_group("session recording")
@@ -322,6 +330,28 @@ def setup_replay_target(replay_path: str, symbol_search: List[str],
     return prog
 
 
+def _load_external_command_paths(args: argparse.Namespace, quiet: bool) -> None:
+    """Load external commands from --load-commands flags and SDB_COMMANDS_PATH."""
+    from sdb.loader import load_external_commands
+
+    paths = list(args.load_commands)
+
+    env_paths = os.environ.get("SDB_COMMANDS_PATH", "")
+    if env_paths:
+        for p in env_paths.split(":"):
+            if p.strip():
+                paths.append(p.strip())
+
+    for path in paths:
+        try:
+            new_names = load_external_commands(path)
+            if not quiet and new_names:
+                print(f"sdb: loaded {len(new_names)} command(s) from {path}",
+                      file=sys.stderr)
+        except (FileNotFoundError, ImportError, ValueError) as e:
+            print(f"sdb: warning: {e}", file=sys.stderr)
+
+
 def _run_replay_mode(args: argparse.Namespace) -> None:
     """Handle replay mode execution."""
     try:
@@ -342,6 +372,7 @@ def _run_replay_mode(args: argparse.Namespace) -> None:
             sdb.target.set_thread(0)
 
     sdb.target.set_frame(-1)
+    _load_external_command_paths(args, args.quiet)
     sdb.register_commands()
 
     if not args.quiet:
@@ -369,6 +400,7 @@ def _run_normal_mode(args: argparse.Namespace) -> None:
     except ValueError:
         sdb.target.set_thread(next(prog.threads()).object)
     sdb.target.set_frame(-1)
+    _load_external_command_paths(args, args.quiet)
     sdb.register_commands()
 
     # Handle recording mode

--- a/sdb/internal/repl.py
+++ b/sdb/internal/repl.py
@@ -23,6 +23,7 @@ from typing import Callable, List, Optional, Tuple
 
 import drgn
 from sdb.error import Error, CommandArgumentsError
+from sdb.loader import load_external_commands
 from sdb.pipeline import invoke
 from sdb.session import get_trace_manager
 
@@ -65,16 +66,19 @@ class REPL:
 
         return custom_complete
 
-    def __init__(self,
-                 target: drgn.Program,
-                 vocabulary: List[str],
-                 prompt: str = "sdb> ",
-                 closing: str = ""):
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+            self,
+            target: drgn.Program,
+            vocabulary: List[str],
+            prompt: str = "sdb> ",
+            closing: str = "",
+            pre_cmd_hook: Optional[Callable[[], None]] = None):
         self.prompt = prompt
         self.closing = closing
         self.vocabulary = vocabulary
         self.target = target
         self.histfile = ""
+        self.pre_cmd_hook = pre_cmd_hook
         readline.set_completer(REPL.__make_completer(vocabulary))
         readline.parse_and_bind("tab: complete")
 
@@ -95,6 +99,35 @@ class REPL:
             return
         readline.set_history_length(1000)
         atexit.register(readline.write_history_file, self.histfile)
+
+    def refresh_vocabulary(self) -> None:
+        """Rebuild the tab-completion vocabulary from registered commands."""
+        from sdb.command import get_registered_commands
+        self.vocabulary = list(get_registered_commands().keys())
+        readline.set_completer(REPL.__make_completer(self.vocabulary))
+
+    def _handle_load_commands(self, args: List[str]) -> int:
+        """Handle %load-commands <path> meta-command."""
+        if not args:
+            print("Usage: %load-commands <file-or-directory>")
+            return 2
+
+        from sdb.command import register_commands
+        path = args[0]
+        try:
+            new_names = load_external_commands(path)
+        except (FileNotFoundError, ImportError, ValueError) as e:
+            print(f"Error loading commands: {e}")
+            return 1
+
+        register_commands()
+        self.refresh_vocabulary()
+
+        if new_names:
+            print(f"Loaded {len(new_names)} command(s): {', '.join(new_names)}")
+        else:
+            print(f"No new commands found in {path}")
+        return 0
 
     def _parse_session_cmd(self, input_: str) -> Tuple[str, List[str]]:
         """Parse session command input into subcmd and args."""
@@ -325,6 +358,7 @@ class REPL:
         - %session snapshot <var> [--depth N] - Capture object graph
         - %session record-memory <addr> <size> - Capture memory region
         - %session load <file> - Load a recorded session
+        - %load-commands <path> - Load external sdb commands
 
         Returns:
             0 for success
@@ -341,9 +375,12 @@ class REPL:
                 )
                 return 2
 
+            if parts[0] == 'load-commands':
+                return self._handle_load_commands(parts[1:])
+
             if parts[0] != 'session':
                 print(f"Unknown meta-command: %{parts[0]}")
-                print("Available meta-commands: %session")
+                print("Available meta-commands: %session, %load-commands")
                 return 1
 
             if len(parts) < 2:
@@ -398,6 +435,9 @@ class REPL:
         # Check for session/meta commands (starting with %)
         if input_.startswith('%'):
             return self.eval_session_cmd(input_[1:])
+
+        if self.pre_cmd_hook is not None:
+            self.pre_cmd_hook()
 
         # Check if recording is active
         trace_mgr = get_trace_manager()

--- a/sdb/loader.py
+++ b/sdb/loader.py
@@ -1,0 +1,95 @@
+#
+# Copyright 2025 CoreWeave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+External command loading for sdb.
+
+This module provides the ability to load sdb commands from arbitrary
+filesystem paths -- individual .py files or directories of them. Commands
+are standard sdb.Command subclasses; the existing __init_subclass__
+auto-registration mechanism handles the rest.
+
+Typical usage from the library API::
+
+    sdb.load_external_commands("/path/to/my/commands")
+
+Or from the REPL::
+
+    sdb> %load-commands /path/to/my/commands
+"""
+
+import glob
+import importlib.util
+import os
+import sys
+from typing import List, Set, Type
+
+
+def _import_file(filepath: str) -> None:
+    """Import a single Python file by absolute path."""
+    basename = os.path.splitext(os.path.basename(filepath))[0]
+    module_name = f"sdb_ext.{basename}"
+
+    counter = 0
+    unique_name = module_name
+    while unique_name in sys.modules:
+        counter += 1
+        unique_name = f"{module_name}_{counter}"
+    module_name = unique_name
+
+    spec = importlib.util.spec_from_file_location(module_name, filepath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot create module spec for {filepath}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+
+
+def load_external_commands(path: str) -> List[str]:
+    """
+    Load sdb Command subclasses from an external file or directory.
+
+    If *path* is a ``.py`` file it is imported directly.  If *path* is a
+    directory every ``.py`` file under it (recursively) is imported.
+    Importing triggers ``Command.__init_subclass__`` which adds each new
+    command to ``all_commands``.
+
+    Returns:
+        A list of command names that were newly discovered.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+        ImportError: If a module fails to load.
+    """
+    from sdb.command import Command, all_commands
+
+    before: Set[Type[Command]] = set(all_commands)
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"command path does not exist: {path}")
+
+    if os.path.isfile(path) and path.endswith(".py"):
+        _import_file(path)
+    elif os.path.isdir(path):
+        for py_file in sorted(
+                glob.glob(os.path.join(path, "**", "*.py"), recursive=True)):
+            if os.path.basename(py_file).startswith("__"):
+                continue
+            _import_file(py_file)
+    else:
+        raise ValueError(f"path must be a .py file or a directory, got: {path}")
+
+    new_commands = all_commands - before
+    return [name for cls in new_commands for name in cls.names]

--- a/tests/unit/data/sample_commands/bad_syntax.py.disabled
+++ b/tests/unit/data/sample_commands/bad_syntax.py.disabled
@@ -1,0 +1,5 @@
+"""
+This file has a .disabled extension so it won't be imported by the loader.
+It exists so tests can rename it to .py to test import-error handling.
+"""
+this is not valid python !!!

--- a/tests/unit/data/sample_commands/greet.py
+++ b/tests/unit/data/sample_commands/greet.py
@@ -12,6 +12,5 @@ class Greet(sdb.Command):
     names = ["greet_ext"]
     load_on = [sdb.All()]
 
-    def _call(self,
-              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+    def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         return objs

--- a/tests/unit/data/sample_commands/greet.py
+++ b/tests/unit/data/sample_commands/greet.py
@@ -1,0 +1,17 @@
+"""Another sample external command for testing the plugin loader."""
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class Greet(sdb.Command):
+    """Second test command -- used by loader unit tests."""
+
+    names = ["greet_ext"]
+    load_on = [sdb.All()]
+
+    def _call(self,
+              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+        return objs

--- a/tests/unit/data/sample_commands/hello.py
+++ b/tests/unit/data/sample_commands/hello.py
@@ -1,0 +1,17 @@
+"""Sample external command for testing the plugin loader."""
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class Hello(sdb.Command):
+    """Print a greeting -- used by loader unit tests."""
+
+    names = ["hello_ext"]
+    load_on = [sdb.All()]
+
+    def _call(self,
+              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+        return objs

--- a/tests/unit/data/sample_commands/hello.py
+++ b/tests/unit/data/sample_commands/hello.py
@@ -12,6 +12,5 @@ class Hello(sdb.Command):
     names = ["hello_ext"]
     load_on = [sdb.All()]
 
-    def _call(self,
-              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+    def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         return objs

--- a/tests/unit/data/sample_commands/kernel_only.py
+++ b/tests/unit/data/sample_commands/kernel_only.py
@@ -1,0 +1,17 @@
+"""Sample command that only loads on kernel targets."""
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class KernelOnly(sdb.Command):
+    """Test command restricted to kernel runtime."""
+
+    names = ["kernel_only_ext"]
+    load_on = [sdb.Kernel()]
+
+    def _call(self,
+              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+        return objs

--- a/tests/unit/data/sample_commands/kernel_only.py
+++ b/tests/unit/data/sample_commands/kernel_only.py
@@ -12,6 +12,5 @@ class KernelOnly(sdb.Command):
     names = ["kernel_only_ext"]
     load_on = [sdb.Kernel()]
 
-    def _call(self,
-              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+    def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         return objs

--- a/tests/unit/data/sample_commands_subdir/sub/nested.py
+++ b/tests/unit/data/sample_commands_subdir/sub/nested.py
@@ -12,6 +12,5 @@ class Nested(sdb.Command):
     names = ["nested_ext"]
     load_on = [sdb.All()]
 
-    def _call(self,
-              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+    def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         return objs

--- a/tests/unit/data/sample_commands_subdir/sub/nested.py
+++ b/tests/unit/data/sample_commands_subdir/sub/nested.py
@@ -1,0 +1,17 @@
+"""Nested command in a subdirectory."""
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class Nested(sdb.Command):
+    """Nested test command in sub-directory."""
+
+    names = ["nested_ext"]
+    load_on = [sdb.All()]
+
+    def _call(self,
+              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+        return objs

--- a/tests/unit/data/sample_commands_subdir/top_level.py
+++ b/tests/unit/data/sample_commands_subdir/top_level.py
@@ -12,6 +12,5 @@ class TopLevel(sdb.Command):
     names = ["top_level_ext"]
     load_on = [sdb.All()]
 
-    def _call(self,
-              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+    def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
         return objs

--- a/tests/unit/data/sample_commands_subdir/top_level.py
+++ b/tests/unit/data/sample_commands_subdir/top_level.py
@@ -1,0 +1,17 @@
+"""Top-level command in a nested directory structure."""
+
+from typing import Iterable
+
+import drgn
+import sdb
+
+
+class TopLevel(sdb.Command):
+    """Top-level test command in nested dir."""
+
+    names = ["top_level_ext"]
+    load_on = [sdb.All()]
+
+    def _call(self,
+              objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+        return objs

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,0 +1,496 @@
+#
+# Copyright 2025 CoreWeave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Unit tests for the external command loader (sdb.loader) and
+the library API entry point (sdb.start).
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+from typing import Any, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdb.command import all_commands
+from sdb.loader import load_external_commands, _import_file  # pylint: disable=protected-access
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+SAMPLE_COMMANDS_DIR = os.path.join(DATA_DIR, "sample_commands")
+SAMPLE_COMMANDS_SUBDIR = os.path.join(DATA_DIR, "sample_commands_subdir")
+HELLO_FILE = os.path.join(SAMPLE_COMMANDS_DIR, "hello.py")
+
+
+def _command_names() -> List[str]:
+    """Return sorted list of all known command names."""
+    return sorted(n for cls in all_commands for n in cls.names)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_ext_modules() -> Any:
+    """Remove any sdb_ext.* modules after each test so they can be reimported."""
+    yield
+    to_remove = [k for k in sys.modules if k.startswith("sdb_ext.")]
+    for k in to_remove:
+        del sys.modules[k]
+
+
+# ---------------------------------------------------------------------------
+# load_external_commands -- single file
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSingleFile:
+
+    def test_load_single_file(self) -> None:
+        new_names = load_external_commands(HELLO_FILE)
+        assert "hello_ext" in new_names
+
+    def test_load_single_file_names_in_all_commands(self) -> None:
+        load_external_commands(HELLO_FILE)
+        assert "hello_ext" in _command_names()
+
+    def test_load_same_file_twice_is_idempotent(self) -> None:
+        """Loading the same path twice still registers the command."""
+        first = load_external_commands(HELLO_FILE)
+        assert "hello_ext" in first
+        second = load_external_commands(HELLO_FILE)
+        assert "hello_ext" in second
+
+
+# ---------------------------------------------------------------------------
+# load_external_commands -- directory
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDirectory:
+
+    def test_load_flat_directory(self) -> None:
+        new_names = load_external_commands(SAMPLE_COMMANDS_DIR)
+        assert "hello_ext" in new_names
+        assert "greet_ext" in new_names
+        assert "kernel_only_ext" in new_names
+
+    def test_load_nested_directory(self) -> None:
+        new_names = load_external_commands(SAMPLE_COMMANDS_SUBDIR)
+        assert "top_level_ext" in new_names
+        assert "nested_ext" in new_names
+
+    def test_skips_dunder_files(self) -> None:
+        """__init__.py and __pycache__ files should be skipped."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            init_path = os.path.join(tmpdir, "__init__.py")
+            with open(init_path, "w", encoding="utf-8") as f:
+                f.write("# should be skipped\n")
+            cmd_path = os.path.join(tmpdir, "real_cmd.py")
+            with open(cmd_path, "w", encoding="utf-8") as f:
+                f.write("import sdb\n"
+                        "class SkipTest(sdb.Command):\n"
+                        "    names = ['skip_test_ext']\n"
+                        "    load_on = [sdb.All()]\n"
+                        "    def _call(self, objs):\n"
+                        "        yield from objs\n")
+            new_names = load_external_commands(tmpdir)
+            assert "skip_test_ext" in new_names
+        finally:
+            shutil.rmtree(tmpdir)
+
+
+# ---------------------------------------------------------------------------
+# load_external_commands -- error handling
+# ---------------------------------------------------------------------------
+
+
+class TestLoadErrors:
+
+    def test_nonexistent_path_raises(self) -> None:
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            load_external_commands("/no/such/path/commands")
+
+    def test_non_py_file_raises(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".txt",
+                                         delete=False) as tmpfile:
+            tmpfile_name = tmpfile.name
+        try:
+            with pytest.raises(ValueError, match="must be a .py file"):
+                load_external_commands(tmpfile_name)
+        finally:
+            os.unlink(tmpfile_name)
+
+    def test_bad_syntax_raises(self) -> None:
+        tmpdir = tempfile.mkdtemp()
+        try:
+            bad_file = os.path.join(tmpdir, "bad.py")
+            with open(bad_file, "w", encoding="utf-8") as f:
+                f.write("this is not valid python !!!\n")
+            with pytest.raises(SyntaxError):
+                load_external_commands(bad_file)
+        finally:
+            shutil.rmtree(tmpdir)
+
+
+# ---------------------------------------------------------------------------
+# _import_file -- low-level
+# ---------------------------------------------------------------------------
+
+
+class TestImportFile:
+
+    def test_import_file_adds_to_sys_modules(self) -> None:
+        _import_file(HELLO_FILE)
+        matching = [k for k in sys.modules if k.startswith("sdb_ext.hello")]
+        assert len(matching) >= 1
+
+    def test_import_file_deduplication(self) -> None:
+        """Importing the same file twice gets unique module names."""
+        _import_file(HELLO_FILE)
+        _import_file(HELLO_FILE)
+        matching = [k for k in sys.modules if k.startswith("sdb_ext.hello")]
+        assert len(matching) >= 2
+
+
+# ---------------------------------------------------------------------------
+# SDB_COMMANDS_PATH environment variable
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVar:  # pylint: disable=too-few-public-methods
+
+    def test_env_var_loads_commands(self) -> None:
+        """sdb.start() should honour SDB_COMMANDS_PATH."""
+        import sdb
+
+        mock_prog = MagicMock()
+        mock_prog.flags = 0
+        mock_prog.threads.return_value = iter([])
+        mock_prog.crashed_thread.side_effect = ValueError
+
+        with patch.dict(os.environ, {"SDB_COMMANDS_PATH": SAMPLE_COMMANDS_DIR}):
+            with patch.object(sdb, "register_commands"):
+                with patch("sdb.internal.repl.REPL") as mock_repl_cls:
+                    mock_repl = MagicMock()
+                    mock_repl_cls.return_value = mock_repl
+                    with patch("sdb.target.set_prog"):
+                        with patch("sdb.target.set_thread"):
+                            with patch("sdb.target.set_frame"):
+                                try:
+                                    sdb.start(mock_prog, eval_cmd="echo 0x0")
+                                except SystemExit:
+                                    pass
+
+        assert "hello_ext" in _command_names()
+
+
+# ---------------------------------------------------------------------------
+# CLI --load-commands
+# ---------------------------------------------------------------------------
+
+
+class TestCLILoadCommands:
+
+    def test_load_external_command_paths(self) -> None:
+        """_load_external_command_paths should process args.load_commands."""
+        import argparse
+        from sdb.internal.cli import _load_external_command_paths
+
+        args = argparse.Namespace(load_commands=[SAMPLE_COMMANDS_DIR])
+        with patch.dict(os.environ, {}, clear=True):
+            _load_external_command_paths(args, quiet=True)
+
+        assert "hello_ext" in _command_names()
+        assert "greet_ext" in _command_names()
+
+    def test_load_external_command_paths_with_env(self) -> None:
+        """SDB_COMMANDS_PATH should also be honoured by the CLI helper."""
+        import argparse
+        from sdb.internal.cli import _load_external_command_paths
+
+        args = argparse.Namespace(load_commands=[])
+        with patch.dict(os.environ,
+                        {"SDB_COMMANDS_PATH": SAMPLE_COMMANDS_SUBDIR}):
+            _load_external_command_paths(args, quiet=True)
+
+        assert "top_level_ext" in _command_names()
+        assert "nested_ext" in _command_names()
+
+    def test_bad_path_prints_warning(self, capsys: Any) -> None:
+        """A missing path should produce a warning, not crash."""
+        import argparse
+        from sdb.internal.cli import _load_external_command_paths
+
+        args = argparse.Namespace(load_commands=["/no/such/dir"])
+        with patch.dict(os.environ, {}, clear=True):
+            _load_external_command_paths(args, quiet=False)
+
+        captured = capsys.readouterr()
+        assert "does not exist" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# REPL %load-commands meta-command
+# ---------------------------------------------------------------------------
+
+
+class TestREPLLoadCommands:
+
+    def _make_repl(self) -> Any:
+        from sdb.internal.repl import REPL
+        mock_prog = MagicMock(spec_set=["flags", "platform"])
+        mock_prog.flags = 0
+        mock_prog.platform = "test"
+        return REPL(mock_prog, ["echo", "help"])
+
+    def test_load_commands_success(self) -> None:
+        repl = self._make_repl()
+        result = repl.eval_session_cmd(f"load-commands {SAMPLE_COMMANDS_DIR}")
+        assert result == 0
+
+    def test_load_commands_no_args(self, capsys: Any) -> None:
+        repl = self._make_repl()
+        result = repl.eval_session_cmd("load-commands")
+        assert result == 2
+        assert "Usage" in capsys.readouterr().out
+
+    def test_load_commands_bad_path(self, capsys: Any) -> None:
+        repl = self._make_repl()
+        result = repl.eval_session_cmd("load-commands /no/such/path")
+        assert result == 1
+        assert "Error" in capsys.readouterr().out
+
+    def test_load_commands_refreshes_vocabulary(self) -> None:
+        repl = self._make_repl()
+        old_vocab = list(repl.vocabulary)
+        repl.eval_session_cmd(f"load-commands {SAMPLE_COMMANDS_DIR}")
+        assert len(repl.vocabulary) > len(old_vocab)
+
+    def test_unknown_meta_command(self, capsys: Any) -> None:
+        repl = self._make_repl()
+        result = repl.eval_session_cmd("bogus-thing")
+        assert result == 1
+        assert "%load-commands" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# REPL pre_cmd_hook
+# ---------------------------------------------------------------------------
+
+
+class TestPreCmdHook:
+
+    def test_hook_called_on_eval(self) -> None:
+        from sdb.internal.repl import REPL
+        hook = MagicMock()
+        mock_prog = MagicMock(spec_set=["flags", "platform"])
+        mock_prog.flags = 0
+        mock_prog.platform = "test"
+        repl = REPL(mock_prog, ["echo"], pre_cmd_hook=hook)
+
+        with patch("sdb.internal.repl.invoke", return_value=iter([])):
+            with patch("sdb.internal.repl.get_trace_manager") as mock_tm:
+                mock_tm.return_value.is_recording = False
+                repl.eval_cmd("echo 0x0")
+
+        hook.assert_called_once()
+
+    def test_hook_not_called_for_meta_commands(self) -> None:
+        from sdb.internal.repl import REPL
+        hook = MagicMock()
+        mock_prog = MagicMock(spec_set=["flags", "platform"])
+        mock_prog.flags = 0
+        mock_prog.platform = "test"
+        repl = REPL(mock_prog, ["echo"], pre_cmd_hook=hook)
+
+        repl.eval_cmd(f"%load-commands {SAMPLE_COMMANDS_DIR}")
+
+        hook.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Library API -- sdb.start()
+# ---------------------------------------------------------------------------
+
+
+class TestLibraryAPI:
+
+    def test_start_accepts_external_program(self) -> None:
+        """sdb.start() should install the provided program and run the REPL."""
+        import sdb
+        import sdb.target as sdb_target
+
+        mock_prog = MagicMock()
+        mock_prog.flags = 0
+        mock_prog.threads.return_value = iter([])
+        mock_prog.crashed_thread.side_effect = ValueError
+
+        with patch("sdb.internal.repl.REPL") as mock_repl_cls:
+            mock_repl = MagicMock()
+            mock_repl.eval_cmd.return_value = 0
+            mock_repl_cls.return_value = mock_repl
+            with patch.object(sdb_target, "set_prog") as mock_set_prog:
+                with patch.object(sdb_target, "set_thread"):
+                    with patch.object(sdb_target, "set_frame"):
+                        with patch.object(sdb, "register_commands"):
+                            try:
+                                sdb.start(mock_prog, eval_cmd="echo 0x0")
+                            except SystemExit:
+                                pass
+
+            mock_set_prog.assert_called_once_with(mock_prog)
+            mock_repl.eval_cmd.assert_called_once_with("echo 0x0")
+
+    def test_start_loads_command_paths(self) -> None:
+        """sdb.start() should load commands from provided paths."""
+        import sdb
+        import sdb.target as sdb_target
+
+        mock_prog = MagicMock()
+        mock_prog.flags = 0
+        mock_prog.threads.return_value = iter([])
+        mock_prog.crashed_thread.side_effect = ValueError
+
+        with patch("sdb.internal.repl.REPL") as mock_repl_cls:
+            mock_repl = MagicMock()
+            mock_repl.eval_cmd.return_value = 0
+            mock_repl_cls.return_value = mock_repl
+            with patch.object(sdb_target, "set_prog"):
+                with patch.object(sdb_target, "set_thread"):
+                    with patch.object(sdb_target, "set_frame"):
+                        with patch.object(sdb, "register_commands"):
+                            try:
+                                sdb.start(
+                                    mock_prog,
+                                    command_paths=[SAMPLE_COMMANDS_DIR],
+                                    eval_cmd="echo 0x0",
+                                )
+                            except SystemExit:
+                                pass
+
+        assert "hello_ext" in _command_names()
+        assert "greet_ext" in _command_names()
+
+    def test_start_passes_prompt(self) -> None:
+        """sdb.start() should forward the prompt to the REPL."""
+        import sdb
+        import sdb.target as sdb_target
+
+        mock_prog = MagicMock()
+        mock_prog.flags = 0
+        mock_prog.threads.return_value = iter([])
+        mock_prog.crashed_thread.side_effect = ValueError
+
+        with patch("sdb.internal.repl.REPL") as mock_repl_cls:
+            mock_repl = MagicMock()
+            mock_repl.eval_cmd.return_value = 0
+            mock_repl_cls.return_value = mock_repl
+            with patch.object(sdb_target, "set_prog"):
+                with patch.object(sdb_target, "set_thread"):
+                    with patch.object(sdb_target, "set_frame"):
+                        with patch.object(sdb, "register_commands"):
+                            try:
+                                sdb.start(mock_prog,
+                                          prompt="gw> ",
+                                          eval_cmd="echo 0x0")
+                            except SystemExit:
+                                pass
+
+            _, kwargs = mock_repl_cls.call_args
+            assert kwargs["prompt"] == "gw> "
+
+    def test_start_passes_pre_cmd_hook(self) -> None:
+        """sdb.start() should forward pre_cmd_hook to the REPL."""
+        import sdb
+        import sdb.target as sdb_target
+
+        mock_prog = MagicMock()
+        mock_prog.flags = 0
+        mock_prog.threads.return_value = iter([])
+        mock_prog.crashed_thread.side_effect = ValueError
+
+        hook = MagicMock()
+
+        with patch("sdb.internal.repl.REPL") as mock_repl_cls:
+            mock_repl = MagicMock()
+            mock_repl.eval_cmd.return_value = 0
+            mock_repl_cls.return_value = mock_repl
+            with patch.object(sdb_target, "set_prog"):
+                with patch.object(sdb_target, "set_thread"):
+                    with patch.object(sdb_target, "set_frame"):
+                        with patch.object(sdb, "register_commands"):
+                            try:
+                                sdb.start(mock_prog,
+                                          pre_cmd_hook=hook,
+                                          eval_cmd="echo 0x0")
+                            except SystemExit:
+                                pass
+
+            _, kwargs = mock_repl_cls.call_args
+            assert kwargs["pre_cmd_hook"] is hook
+
+    def test_start_interactive_mode(self) -> None:
+        """Without eval_cmd, sdb.start() should call start_session()."""
+        import sdb
+        import sdb.target as sdb_target
+
+        mock_prog = MagicMock()
+        mock_prog.flags = 0
+        mock_prog.threads.return_value = iter([])
+        mock_prog.crashed_thread.side_effect = ValueError
+
+        with patch("sdb.internal.repl.REPL") as mock_repl_cls:
+            mock_repl = MagicMock()
+            mock_repl_cls.return_value = mock_repl
+            with patch.object(sdb_target, "set_prog"):
+                with patch.object(sdb_target, "set_thread"):
+                    with patch.object(sdb_target, "set_frame"):
+                        with patch.object(sdb, "register_commands"):
+                            sdb.start(mock_prog)
+
+            mock_repl.start_session.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# REPL.refresh_vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshVocabulary:  # pylint: disable=too-few-public-methods
+
+    def test_refresh_updates_vocabulary(self) -> None:
+        from sdb.internal.repl import REPL
+        mock_prog = MagicMock(spec_set=["flags", "platform"])
+        mock_prog.flags = 0
+        mock_prog.platform = "test"
+        repl = REPL(mock_prog, ["old_cmd"])
+
+        assert "old_cmd" in repl.vocabulary
+
+        with patch("sdb.command.get_registered_commands",
+                   return_value={
+                       "new_a": None,
+                       "new_b": None,
+                   }):
+            repl.refresh_vocabulary()
+
+        assert "new_a" in repl.vocabulary
+        assert "new_b" in repl.vocabulary


### PR DESCRIPTION
Add the ability to load sdb commands from arbitrary filesystem paths and use sdb as a library with an externally-provided drgn.Program. This enables tools like GhostWire to drive sdb for remote kernel introspection without leaking private code into the public sdb repo.

New modules and APIs:
- sdb.loader: load_external_commands() imports Command subclasses from external .py files or directories, leveraging the existing __init_subclass__ auto-registration mechanism.
- sdb.start(): high-level entry point that accepts a pre-configured drgn.Program, optional command paths, a custom prompt, and a pre_cmd_hook callback (e.g. for cache generation bumping).

New CLI/REPL features:
- --load-commands PATH flag (repeatable) for the sdb CLI.
- SDB_COMMANDS_PATH environment variable (colon-separated paths).
- %load-commands <path> REPL meta-command for interactive loading.
- REPL pre_cmd_hook for running a callback before each command.
- REPL.refresh_vocabulary() for updating tab-completion after dynamically loading commands.

Tests cover: single-file and directory loading, nested directories, error handling (missing paths, bad syntax, non-.py files), the REPL %load-commands flow, pre_cmd_hook invocation, the library API (sdb.start with external program, command paths, prompt, hook), CLI --load-commands, and SDB_COMMANDS_PATH integration.