### PR TITLE
docs: add ReadTheDocs documentation site

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: requirements-docs.txt

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <p align="center">
     <a href="https://github.com/sdimitro/sdb/actions/workflows/main.yml"><img src="https://github.com/sdimitro/sdb/actions/workflows/main.yml/badge.svg" alt="CI"></a>
     <a href="https://codecov.io/gh/sdimitro/sdb"><img src="https://codecov.io/gh/sdimitro/sdb/graph/badge.svg" alt="Codecov"></a>
+    <a href="https://sdb-debugger.readthedocs.io/"><img src="https://readthedocs.org/projects/sdb-debugger/badge/?version=latest" alt="Documentation"></a>
     <a href="https://pypi.org/project/sdb-debugger/"><img src="https://img.shields.io/pypi/v/sdb-debugger" alt="PyPI"></a>
     <a href="https://pypi.org/project/sdb-debugger/"><img src="https://img.shields.io/pypi/pyversions/sdb-debugger" alt="Python Versions"></a>
     <a href="https://github.com/sdimitro/sdb/blob/master/LICENSE"><img src="https://img.shields.io/github/license/sdimitro/sdb" alt="License"></a>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,5 @@
+Changelog
+=========
+
+See the `GitHub releases <https://github.com/sdimitro/sdb/releases>`_ page for
+the full changelog.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,33 @@
+project = "sdb"
+copyright = "2019 Delphix, 2025 CoreWeave"
+author = "Serapheim Dimitropoulos"
+
+try:
+    from sdb._version import version as release
+except ImportError:
+    release = "dev"
+
+extensions = [
+    "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "drgn": ("https://drgn.readthedocs.io/en/latest", None),
+}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build"]
+
+html_theme = "furo"
+html_title = "sdb"
+
+html_theme_options = {
+    "source_repository": "https://github.com/sdimitro/sdb",
+    "source_branch": "master",
+    "source_directory": "docs/",
+}
+
+copybutton_prompt_text = r"sdb> |\$ |>>> "
+copybutton_prompt_is_regexp = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,65 @@
+===
+sdb
+===
+
+**The Slick/Simple Debugger** -- a pipeline-based debugger for Linux kernel
+and userland, built on `drgn <https://drgn.readthedocs.io/>`_.
+
+sdb attaches to a live kernel, a running process, or a crash/core dump and
+provides a composable set of commands connected by pipes::
+
+   sdb> stacks -m zfs | count
+   (unsigned long long)12
+
+   sdb> find_task 1 | member comm
+   (char [16])"systemd"
+
+   sdb> spa | member spa_name ! sort
+   (char [256])"data"
+   (char [256])"rpool"
+
+Features
+--------
+
+* **50+ built-in commands** for Linux kernel internals, ZFS, and SPL data
+  structures.
+* **Pipeline architecture** -- compose commands with ``|`` and pipe to the
+  shell with ``!``.
+* **Session recording** -- capture memory accesses into a portable vmcore
+  and replay offline.
+* **Extensible** -- write your own commands in Python and load them at
+  runtime.
+* **Library API** -- embed sdb in your own tools (see
+  :doc:`tutorials/library-usage`).
+* **mdb compatibility** -- use the familiar ``symbol::cmd`` syntax.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting Started
+
+   quickstart
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Tutorials
+
+   tutorials/stacks
+   tutorials/recording
+   tutorials/external-commands
+   tutorials/library-usage
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   reference/concepts
+   reference/api
+   reference/commands
+   reference/developer-notes
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Project
+
+   changelog

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,0 +1,196 @@
+Quickstart
+==========
+
+Installation
+------------
+
+From PyPI
+^^^^^^^^^
+
+.. code-block:: bash
+
+   pip install sdb-debugger
+
+From source
+^^^^^^^^^^^
+
+Dependencies:
+
+* Python 3.10+
+* `drgn <https://github.com/osandov/drgn>`_
+* `libkdumpfile <https://github.com/ptesarik/libkdumpfile>`_ (optional --
+  needed for kdump-compressed crash dumps)
+
+.. note::
+
+   For drgn to support kdump files it must be *compiled* with libkdumpfile.
+   Install libkdumpfile **before** installing drgn.
+
+.. code-block:: bash
+
+   git clone https://github.com/sdimitro/sdb.git
+   cd sdb
+   pip install .
+
+For development (editable install with linters and test dependencies):
+
+.. code-block:: bash
+
+   pip install -e ".[dev]"
+
+
+Attaching to a target
+---------------------
+
+Live kernel (default):
+
+.. code-block:: bash
+
+   sudo sdb
+
+Running process:
+
+.. code-block:: bash
+
+   sudo sdb -p <PID>
+
+Crash dump or core dump:
+
+.. code-block:: bash
+
+   sdb <vmlinux | binary> <dump>
+
+Evaluate a single command and exit:
+
+.. code-block:: bash
+
+   sudo sdb -e "stacks | count"
+
+
+First commands
+--------------
+
+Once inside the REPL you can start exploring immediately::
+
+   sdb> find_task 1 | member comm
+   (char [16])"systemd"
+
+   sdb> find_task 1 | stack
+   TASK_STRUCT        STATE             COUNT
+   ==========================================
+   0xffff89cea441dd00 INTERRUPTIBLE         1
+                     __schedule+0x2e5
+                     schedule+0x33
+                     schedule_hrtimeout_range_clock+0xfd
+                     schedule_hrtimeout_range+0x13
+                     ep_poll+0x40a
+                     do_epoll_wait+0xb7
+                     __x64_sys_epoll_wait+0x1e
+                     do_syscall_64+0x57
+                     entry_SYSCALL_64+0x7c
+
+
+Pipes
+-----
+
+sdb commands are composed using the ``|`` operator, just like a Unix shell.
+Each command receives drgn objects from the command before it and yields drgn
+objects to the next::
+
+   sdb> threads | filter obj.comm == "kworker/0:0" | stack
+
+The pipeline flows left to right.  Some commands (called *Locators*) can
+start a pipeline by producing objects on their own -- ``threads``, ``stacks``,
+``slabs``, ``spa``, and many others work this way.
+
+To pipe sdb output into a **shell command**, use ``!``::
+
+   sdb> addr modules | lxlist "struct module" list | member name ! sort | head -n 3
+   (char [56])"aesni_intel"
+   (char [56])"async_memcpy"
+   (char [56])"async_pq"
+
+Everything after ``!`` is passed to ``/bin/sh``, so standard Unix tools like
+``sort``, ``head``, ``grep``, ``wc``, etc. all work.
+
+
+Entering the pipeline: ``echo`` and ``addr``
+---------------------------------------------
+
+Not every pipeline starts from a Locator.  Two commands let you inject objects
+into the pipeline manually:
+
+``addr``
+   Resolve a symbol name or hex address to a drgn object.  This is the primary
+   way to start a pipeline from a global variable::
+
+      sdb> addr jiffies
+      *(volatile unsigned long *)0xffffffff97205000 = 4901248625
+
+      sdb> addr jiffies | deref
+      (volatile unsigned long)4905392949
+
+   Multiple symbols can be given at once::
+
+      sdb> addr jiffies slab_caches 0xffffdeadbeef
+
+``echo``
+   Create a ``void *`` from a raw numeric address::
+
+      sdb> echo 0xffff9d0adbe2c000 | cast spa_t * | member spa_name
+      (char [256])"rpool"
+
+
+Casting
+-------
+
+When a command expects a specific pointer type, sdb automatically casts
+``void *`` inputs.  You can also cast explicitly::
+
+   sdb> echo 0xffff9d0adbe2c000 | cast spa_t *
+
+This is useful when starting from a raw address found in a log or another
+tool.  The ``cast`` command accepts any C type expression that drgn can
+resolve.
+
+
+Getting help
+------------
+
+Every command has built-in help accessible from the REPL:
+
+.. code-block:: none
+
+   sdb> help stacks
+   SUMMARY
+       stacks [-h] [-a] [-v] [-l] [-c FUNCTION] [-m MODULE] [-t TSTATE]
+
+       Print the stack traces for active threads (task_struct)
+   ...
+
+``help`` and ``man`` are aliases for the same command.
+
+To list all registered walkers and their types::
+
+   sdb> walk
+
+
+mdb compatibility syntax
+------------------------
+
+If you are coming from illumos/Solaris and are used to mdb, sdb understands
+the ``symbol::cmd`` shorthand::
+
+   sdb> spa_namespace_avl::walk
+
+This is automatically transformed to ``addr spa_namespace_avl | walk`` before
+execution.  Inside a pipeline the leading ``::`` is simply stripped::
+
+   sdb> spa | ::member spa_name
+
+becomes ``spa | member spa_name``.
+
+mdb compatibility is enabled by default.  Disable it with ``--no-mdb-compat``
+if it ever conflicts with something::
+
+   $ sudo sdb --no-mdb-compat

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -1,0 +1,313 @@
+Public API reference
+====================
+
+This page documents the public Python API exported by the ``sdb`` package.
+Everything listed here is part of ``sdb.__all__`` and is considered stable.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+Entry point
+-----------
+
+.. function:: sdb.start(prog, command_paths=None, prompt="sdb> ", pre_cmd_hook=None, eval_cmd=None, history_file="~/.sdb_history")
+
+   High-level entry point for using sdb as a library.
+
+   Accepts a pre-configured :class:`drgn.Program` and starts the sdb REPL
+   (or evaluates a single command if *eval_cmd* is given).
+
+   :param prog: A fully initialised ``drgn.Program``.
+   :param command_paths: Optional list of filesystem paths (files or
+       directories) from which to load additional sdb commands.
+   :param prompt: REPL prompt string, or an object whose ``__str__`` is
+       called each time the prompt is displayed.
+   :param pre_cmd_hook: Optional callable (no arguments) invoked before
+       every command evaluation.
+   :param eval_cmd: If provided, evaluate this single command string and
+       return instead of starting the interactive REPL.
+   :param history_file: Path for readline history persistence.
+
+   Example:
+
+   .. code-block:: python
+
+      import drgn, sdb
+
+      prog = drgn.Program()
+      prog.set_kernel()
+      prog.load_default_debug_info()
+
+      sdb.start(prog, prompt="mydb> ")
+
+
+Pipeline execution
+------------------
+
+.. function:: sdb.invoke(first_input, line)
+
+   Parse and execute an sdb pipeline string.
+
+   :param first_input: An iterable of ``drgn.Object`` to feed as initial
+       input (pass ``[]`` to start from scratch).
+   :param line: The pipeline string, e.g. ``"stacks -t D | count"``.
+   :returns: A generator yielding ``drgn.Object`` results.
+
+   Example:
+
+   .. code-block:: python
+
+      for obj in sdb.invoke([], "spa | member spa_name"):
+          print(obj.string_().decode())
+
+.. function:: sdb.execute_pipeline(first_input, pipeline)
+
+   Execute a pre-built list of ``Command`` objects.
+
+   :param first_input: Iterable of ``drgn.Object``.
+   :param pipeline: A list of instantiated ``Command`` objects.
+   :returns: Generator of ``drgn.Object``.
+
+.. function:: sdb.get_first_type(objs)
+
+   Peek at the type of the first object in an iterable without consuming it.
+
+   :param objs: An iterable of ``drgn.Object``.
+   :returns: A tuple ``(drgn.Type, iterable)`` where the iterable contains
+       the same objects (including the first one).
+
+   Example:
+
+   .. code-block:: python
+
+      first_type, objs = sdb.get_first_type(objs)
+
+
+External command loading
+------------------------
+
+.. function:: sdb.load_external_commands(path)
+
+   Import sdb commands from a ``.py`` file or a directory of them.
+
+   :param path: Filesystem path.  If a directory, all ``.py`` files are
+       imported recursively (files starting with ``__`` are skipped).
+   :returns: A list of command name strings that were newly discovered.
+   :raises FileNotFoundError: If *path* does not exist.
+   :raises ImportError: If a module fails to load.
+
+   After loading, call :func:`sdb.register_commands` to make the new
+   commands available in the REPL.
+
+
+Command registration
+--------------------
+
+.. function:: sdb.register_commands()
+
+   Register all known command classes that are appropriate for the current
+   runtime (kernel vs. userland).  This is called automatically by
+   :func:`sdb.start`; call it manually only when setting up sdb without
+   ``start()``.
+
+.. function:: sdb.get_registered_commands()
+
+   Return a dict mapping command name strings to ``Command`` subclasses.
+
+
+Target helpers
+--------------
+
+These functions access the ``drgn.Program`` and its state.  They are
+available after ``sdb.start()`` has been called or after manually calling
+``sdb.target.set_prog()``.
+
+.. function:: sdb.get_prog()
+
+   Return the current ``drgn.Program``.
+
+.. function:: sdb.get_object(name)
+
+   Look up a global variable or symbol by name and return it as a
+   ``drgn.Object``.
+
+.. function:: sdb.create_object(type, value)
+
+   Create a ``drgn.Object`` of the given type with the given value.
+
+   :param type: A type string (e.g. ``"void *"``, ``"int"``).
+   :param value: An integer value.
+
+.. function:: sdb.get_type(name)
+
+   Look up a C type by name and return a ``drgn.Type``.
+
+.. function:: sdb.get_symbol(obj)
+
+   Return the ``drgn.Symbol`` for an object or address.
+
+.. function:: sdb.get_pointer_type(type)
+
+   Given a ``drgn.Type``, return the corresponding pointer type.
+
+.. function:: sdb.is_null(obj)
+
+   Return ``True`` if *obj* is a null pointer.
+
+.. function:: sdb.get_target_flags()
+
+   Return the ``drgn.ProgramFlags`` for the current program.
+
+
+Thread and frame state
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. function:: sdb.set_thread(thread)
+
+   Set the current thread context.
+
+.. function:: sdb.get_thread()
+
+   Return the current thread object.
+
+.. function:: sdb.set_frame(frame)
+
+   Set the current stack frame index (``-1`` for the topmost frame).
+
+.. function:: sdb.get_frame()
+
+   Return the current stack frame index.
+
+
+Type utilities
+^^^^^^^^^^^^^^
+
+.. function:: sdb.type_canonical_name(type)
+
+   Return the canonical name for a ``drgn.Type`` (resolves typedefs).
+
+.. function:: sdb.type_canonicalize(type)
+
+   Resolve all typedefs and return the underlying ``drgn.Type``.
+
+.. function:: sdb.type_canonicalize_name(name)
+
+   Like ``type_canonical_name`` but accepts a type name string.
+
+.. function:: sdb.type_canonicalize_size(type)
+
+   Return the size of a type after resolving typedefs.
+
+.. function:: sdb.type_equals(a, b)
+
+   Return ``True`` if two ``drgn.Type`` objects refer to the same type
+   (after canonicalization).
+
+
+Command base classes
+--------------------
+
+.. class:: sdb.Command
+
+   Base class for all sdb commands.  See :doc:`developer-notes` for how
+   to subclass it.
+
+.. class:: sdb.SingleInputCommand
+
+   Processes each input object independently; a ``FaultError`` on one
+   object does not abort the pipeline.
+
+.. class:: sdb.Walker
+
+   Iterates over a container data structure.  Implement ``walk(self, obj)``.
+
+.. class:: sdb.PrettyPrinter
+
+   Human-readable formatter.  Implement ``pretty_print(self, objs)``.
+
+.. class:: sdb.Locator
+
+   Finds objects of a given type.  Implement ``no_input(self)`` and
+   optionally ``@InputHandler``-decorated methods.
+
+.. class:: sdb.InputHandler(typename)
+
+   Decorator for methods on Locator subclasses.  Registers the method as
+   the handler for input objects of the given C type.
+
+.. class:: sdb.Address
+
+   Built-in command that resolves symbols and hex addresses.
+
+.. class:: sdb.Cast
+
+   Built-in command that casts objects to a specified type.
+
+.. class:: sdb.Walk
+
+   Built-in dispatch command that selects the appropriate Walker.
+
+
+Runtime markers
+---------------
+
+.. class:: sdb.All
+
+   Load the command for all target types.
+
+.. class:: sdb.Kernel
+
+   Load the command only for kernel targets.
+
+.. class:: sdb.Userland
+
+   Load the command only for userland targets.
+
+.. class:: sdb.Module(name)
+
+   Load for a specific kernel module (currently equivalent to ``Kernel``).
+
+.. class:: sdb.Library(name)
+
+   Load for a specific shared library (currently equivalent to ``Userland``).
+
+
+Error hierarchy
+---------------
+
+All sdb-specific exceptions inherit from ``sdb.Error``.
+
+.. class:: sdb.Error
+
+   Base exception.
+
+.. class:: sdb.CommandError
+
+   A command encountered a runtime error (e.g. type mismatch, invalid
+   memory).
+
+.. class:: sdb.CommandNotFoundError
+
+   The user typed a command name that is not registered.
+
+.. class:: sdb.CommandInvalidInputError
+
+   A command received input of an unexpected type.
+
+.. class:: sdb.SymbolNotFoundError
+
+   A symbol name could not be resolved.
+
+.. class:: sdb.CommandArgumentsError
+
+   The arguments passed to a command were invalid (raised by argparse).
+
+.. class:: sdb.CommandEvalSyntaxError
+
+   A syntax error in a filter expression.
+
+.. class:: sdb.ParserError
+
+   A parse error in the pipeline syntax.

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -1,0 +1,334 @@
+Command reference
+=================
+
+This page lists every built-in sdb command, grouped by domain.  Use
+``help <command>`` inside the REPL for full details and examples.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+Core commands
+-------------
+
+These are defined in ``sdb/command.py`` and are always available.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **address**
+     - ``addr``
+     - Resolve symbol names or hex addresses to drgn objects; can start a
+       pipeline.
+   * - **cast**
+     -
+     - Cast pipeline objects to a specified C type.
+   * - **deref**
+     -
+     - Dereference pointer objects.
+   * - **walk**
+     -
+     - Dispatch to the appropriate Walker based on input type. With no input,
+       lists all registered walkers.
+
+
+General commands
+----------------
+
+Utility commands available for all target types.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **echo**
+     - ``cc``
+     - Create ``void *`` objects from raw numeric addresses.
+   * - **member**
+     -
+     - Access struct members using ``.``, ``->``, or ``[]`` syntax.
+   * - **filter**
+     -
+     - Filter objects by a Python expression (``obj`` refers to the current
+       object).
+   * - **pyfilter**
+     -
+     - Alias / variant of filter with Python expressions.
+   * - **head**
+     -
+     - Pass through only the first *N* objects.
+   * - **tail**
+     -
+     - Pass through only the last *N* objects.
+   * - **count**
+     - ``cnt``, ``wc``
+     - Count objects in the pipeline and emit the result.
+   * - **sum**
+     -
+     - Sum integer values in the pipeline.
+   * - **type**
+     -
+     - Print the drgn type of each input object.
+   * - **ptype**
+     -
+     - Print the type definition (struct layout, enum values, etc.).
+   * - **sizeof**
+     -
+     - Print the size of a type in bytes.
+   * - **container_of**
+     -
+     - Given a pointer to a struct member, find the containing struct.
+   * - **array**
+     -
+     - Index into array objects.
+   * - **print**
+     -
+     - Format output for scripts (machine-readable).
+   * - **pretty_print**
+     - ``pp``
+     - Pretty-print objects using the registered PrettyPrinter for their type.
+   * - **help**
+     - ``man``
+     - Show help for a command.
+   * - **history**
+     -
+     - Show REPL command history.
+   * - **exit**
+     - ``quit``
+     - Exit the REPL.
+
+
+Linux kernel commands
+---------------------
+
+Available when debugging a kernel target (live or crash dump).
+
+Threads and stacks
+^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **threads**
+     - ``thread``
+     - Locate and print kernel threads (``task_struct``).
+   * - **stacks**
+     - ``stack``
+     - Print aggregated stack traces for threads. Supports filtering by
+       state (``-t``), function (``-c``), and module (``-m``).
+   * - **crashed_thread**
+     - ``panic_stack``, ``panic_thread``
+     - Print the thread that panicked (crash dumps only).
+   * - **trace**
+     - ``bt``
+     - Print a backtrace for a ``task_struct``.
+   * - **stackframe**
+     - ``frame``, ``f``
+     - Select or print a stack frame for a task.
+   * - **locals**
+     - ``local``
+     - Print local variables in the current stack frame.
+   * - **registers**
+     - ``register``
+     - Print register values for a stack frame.
+
+Processes
+^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **find_task**
+     -
+     - Find a ``task_struct`` by PID.
+   * - **pid**
+     -
+     - Find a ``struct pid`` by PID number.
+   * - **fget**
+     -
+     - Get a ``struct file *`` from a file descriptor for a task.
+
+Memory
+^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **slabs**
+     -
+     - List slab caches (``kmem_cache``).
+   * - **slub_cache**
+     -
+     - Walk objects in a SLUB slab cache.
+   * - **percpu**
+     -
+     - Resolve a per-CPU pointer for a given CPU.
+   * - **cpu_counter_sum**
+     -
+     - Sum a per-CPU counter across all CPUs.
+   * - **whatis**
+     -
+     - Identify which kmem cache owns an address.
+
+Data structure walkers
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **linux_list**
+     - ``lxlist``
+     - Walk a ``struct list_head`` linked list.
+   * - **linux_hlist**
+     - ``lxhlist``
+     - Walk a ``struct hlist_head`` hash list.
+   * - **rbtree**
+     -
+     - Walk a red-black tree.
+
+System
+^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **dmesg**
+     -
+     - Print the kernel log buffer.
+
+
+ZFS commands
+------------
+
+Available when the ZFS kernel module is loaded.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **spa**
+     -
+     - Locate and pretty-print SPA (Storage Pool Allocator) objects.
+   * - **vdev**
+     -
+     - Walk and pretty-print vdevs in a pool.
+   * - **metaslab**
+     -
+     - Walk metaslabs for a vdev.
+   * - **zio**
+     -
+     - Iterate and pretty-print ZIO (ZFS I/O) objects.
+   * - **dbuf**
+     -
+     - Iterate and pretty-print dbufs (DMU buffers).
+   * - **arc**
+     -
+     - Print ARC (Adaptive Replacement Cache) statistics.
+   * - **zfs_btree**
+     -
+     - Walk a ZFS B-tree.
+   * - **blkptr**
+     -
+     - Pretty-print a ZFS block pointer.
+   * - **range_tree**
+     -
+     - Pretty-print a range tree.
+   * - **range_seg**
+     -
+     - Locate range segments from a range tree.
+   * - **zfs_histogram**
+     - ``zhist``
+     - Print a ZFS histogram and its median.
+   * - **zfs_dbgmsg**
+     -
+     - Print ZFS debug messages.
+
+
+SPL commands
+------------
+
+Commands for the Solaris Porting Layer data structures.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Command
+     - Aliases
+     - Description
+   * - **avl**
+     -
+     - Walk an AVL tree (``avl_tree_t``).
+   * - **spl_list**
+     -
+     - Walk an SPL ``list_t``.
+   * - **multilist**
+     -
+     - Walk a multilist.
+   * - **spl_kmem_caches**
+     -
+     - List SPL kmem caches.
+   * - **spl_cache**
+     -
+     - Walk objects in an SPL kmem cache.
+
+
+Meta-commands
+-------------
+
+Meta-commands are prefixed with ``%`` and control the REPL itself rather
+than operating on drgn objects.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Command
+     - Description
+   * - ``%load-commands <path>``
+     - Load external sdb commands from a file or directory.
+   * - ``%session record <file>``
+     - Start recording memory accesses to ``<file>.vmcore.recorded``.
+   * - ``%session stop``
+     - Stop recording and save the vmcore.
+   * - ``%session status``
+     - Show recording/replay status and statistics.
+   * - ``%session config [option] [value]``
+     - Configure output format and compression.
+   * - ``%session snapshot <var> [--depth N]``
+     - Capture an object's memory into the recording.
+   * - ``%session record-memory <addr> <size>``
+     - Capture a raw memory region into the recording.
+   * - ``%session load <file>``
+     - Hint to use ``--replay`` for loading recorded sessions.

--- a/docs/reference/concepts.rst
+++ b/docs/reference/concepts.rst
@@ -1,0 +1,233 @@
+Core concepts
+=============
+
+This page explains the key abstractions that make sdb tick.  Understanding
+these concepts will help you read sdb output, compose pipelines effectively,
+and write your own commands.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+The pipeline
+------------
+
+Every sdb expression is a **pipeline** of one or more commands separated by
+``|``.  Data flows left to right as a stream of ``drgn.Object`` values:
+
+.. code-block:: none
+
+   ┌──────────┐     ┌────────┐     ┌────────┐
+   │ Locator  │────▶│ Filter │────▶│ Pretty │
+   │ (source) │     │        │     │ Printer│
+   └──────────┘     └────────┘     └────────┘
+
+The first command in a pipeline either:
+
+* receives no input and produces objects on its own (a *Locator*), or
+* receives objects from a manual source (``echo``, ``addr``).
+
+The last command either:
+
+* pretty-prints its input (if it is a *PrettyPrinter*), or
+* formats each object using drgn's default ``format_()`` method.
+
+Middle commands transform, filter, or walk the stream.
+
+A pipeline can optionally end with ``! <shell command>`` to redirect sdb's
+printed output into a Unix process::
+
+   sdb> stacks | count ! tee /tmp/count.txt
+
+
+Automatic type coercion
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a command declares an ``input_type`` of ``foo_t *``, sdb automatically
+handles two common mismatches:
+
+1. **void \* → foo_t \***:  If the previous command yields ``void *``
+   objects, sdb inserts an implicit ``cast foo_t *`` step.
+
+2. **foo_t → foo_t \***:  If the previous command yields ``foo_t`` (the
+   struct, not a pointer to it), sdb inserts an implicit ``address`` step
+   to take its address.
+
+This means you rarely need to cast manually -- just pipe things together and
+sdb will do the right thing.
+
+
+Command types
+-------------
+
+Every sdb command inherits from ``sdb.Command``.  Several specialised
+subclasses exist, each with a different contract:
+
+Command
+^^^^^^^
+
+The generic base class.  Subclasses implement:
+
+.. code-block:: python
+
+   def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+       ...
+
+The method receives objects from the previous pipeline stage and yields
+objects to the next.  It may also print output as a side effect.
+
+
+SingleInputCommand
+^^^^^^^^^^^^^^^^^^
+
+Like ``Command``, but processes each input object independently.  Subclasses
+implement:
+
+.. code-block:: python
+
+   def _call_one(self, obj: drgn.Object) -> Iterable[drgn.Object]:
+       ...
+
+If one object triggers a ``drgn.FaultError`` (invalid memory), sdb prints
+the error and continues with the next object instead of aborting the entire
+pipeline.  This is useful for commands that iterate over potentially stale
+data structures.
+
+
+Walker
+^^^^^^
+
+A command that iterates over a container data structure.  Subclasses declare
+``input_type`` (e.g. ``"struct list_head *"``) and implement:
+
+.. code-block:: python
+
+   def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
+       ...
+
+Walkers are registered in a global table keyed by their ``input_type``.
+The ``walk`` dispatch command looks up the right walker automatically::
+
+   sdb> addr slab_caches | walk
+
+To see all registered walkers, run ``walk`` with no input::
+
+   sdb> walk
+   The following types have walkers:
+       WALKER              TYPE
+       lxlist              struct list_head *
+       avl                 avl_tree_t *
+       ...
+
+
+PrettyPrinter
+^^^^^^^^^^^^^
+
+A command that produces human-readable output for a specific type.
+Subclasses declare ``input_type`` and implement:
+
+.. code-block:: python
+
+   def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
+       ...
+
+When a PrettyPrinter is the **last** command in a pipeline, sdb calls
+``pretty_print()``.  When it is **not** last, it passes its input through
+unchanged so downstream commands can continue processing.
+
+The ``pp`` (pretty-print) command is a generic dispatcher -- it checks if a
+PrettyPrinter exists for the input type and delegates to it.
+
+
+Locator
+^^^^^^^
+
+A command that **finds** objects of a given type.  Subclasses declare
+``output_type`` (the type being located) and implement:
+
+.. code-block:: python
+
+   def no_input(self) -> Iterable[drgn.Object]:
+       ...
+
+``no_input()`` is called when the Locator is the first command in a
+pipeline (i.e. it has no upstream input).  It should yield all objects of
+the located type.
+
+A Locator can also accept input.  When it receives objects, it dispatches
+to type-specific handlers registered with the ``@InputHandler`` decorator
+(see :doc:`developer-notes`).  If no specific handler matches, the Locator
+tries to use a Walker to iterate the input and cast each element to
+``output_type``.
+
+Many built-in commands (``spa``, ``stacks``, ``threads``, ``slabs``, etc.)
+are **both** a Locator and a PrettyPrinter.  When used to start a pipeline
+they locate objects; when used at the end they pretty-print them; and in the
+middle they pass objects through.
+
+
+Runtimes
+--------
+
+Commands declare when they should be loaded using the ``load_on`` attribute:
+
+====================== ====================================================
+Runtime                When the command is registered
+====================== ====================================================
+``sdb.All()``          Always (e.g. ``cast``, ``echo``, ``help``).
+``sdb.Kernel()``       Only when debugging a kernel target.
+``sdb.Userland()``     Only when debugging a userland process.
+``sdb.Module(name)``   Currently equivalent to ``Kernel()`` -- intended
+                       for kernel module-specific commands.
+``sdb.Library(name)``  Currently equivalent to ``Userland()`` -- intended
+                       for shared library-specific commands.
+====================== ====================================================
+
+This prevents kernel-only commands from appearing when you are debugging a
+userland core, and vice versa.
+
+
+``echo`` and ``addr`` -- entering the pipeline
+-----------------------------------------------
+
+Two built-in commands let you inject objects into a pipeline:
+
+``echo`` (alias ``cc``)
+   Creates a ``void *`` from a raw numeric address.  Useful when you have
+   an address from a log or another tool::
+
+      sdb> echo 0xffff9d0adbe2c000
+
+``addr`` (alias ``address``)
+   Resolves a symbol name **or** hex address to a drgn object, preserving
+   type information::
+
+      sdb> addr jiffies
+      *(volatile unsigned long *)0xffffffff97205000 = 4901248625
+
+   ``addr`` can take multiple arguments::
+
+      sdb> addr jiffies slab_caches 0xffffdeadbeef
+
+The difference: ``echo`` always produces ``void *``; ``addr`` produces a
+typed pointer when given a symbol name.  In practice, ``addr`` is more
+commonly used because you get type information for free.
+
+
+Casting
+-------
+
+Explicit casting with the ``cast`` command:
+
+.. code-block:: none
+
+   sdb> echo 0xffff9d0adbe2c000 | cast spa_t *
+
+``cast`` accepts any C type expression that drgn can resolve, including
+typedefs, qualified types, and pointers to pointers.  It uses
+``drgn.cast()`` under the hood.
+
+As described in `Automatic type coercion`_, most casts happen implicitly
+when piping ``void *`` objects into a command that declares an
+``input_type``.

--- a/docs/reference/developer-notes.rst
+++ b/docs/reference/developer-notes.rst
@@ -1,0 +1,238 @@
+Developer notes
+===============
+
+This page covers the internals you need to know when writing sdb commands
+or embedding sdb in your own tools.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+Writing a new command
+---------------------
+
+Every command is a Python class that inherits from ``sdb.Command`` (or one
+of its subclasses).  The minimum requirements:
+
+1. Set ``names`` to a non-empty list of strings.
+2. Set ``load_on`` to control when the command is registered.
+3. Implement ``_call`` (or the appropriate method for your base class).
+
+Command names must follow C identifier rules: start with a letter or
+underscore, followed by letters, digits, or underscores.  Names starting
+with special characters like ``:``, ``%``, or ``/`` are rejected.
+
+When a module containing your class is imported, ``Command.__init_subclass__``
+automatically adds it to the global command set.  After ``register_commands()``
+runs (which ``sdb.start()`` calls for you), the command is available in the
+REPL with tab completion and ``help``.
+
+
+Docstring conventions
+^^^^^^^^^^^^^^^^^^^^^
+
+The class docstring becomes the command's help text:
+
+* **First line**: one-line summary shown in the ``help`` output header.
+* **Remaining lines**: detailed description and examples.
+
+Format your docstring like the built-in commands:
+
+.. code-block:: python
+
+   class MyCommand(sdb.Command):
+       """
+       One-line summary of what the command does
+
+       DESCRIPTION
+           Longer description of the command's behavior.
+
+       EXAMPLES
+           Show some typical invocations::
+
+               sdb> my_command -v | head 5
+       """
+
+The ``DESCRIPTION`` and ``EXAMPLES`` headings are not mandatory but they
+make the help text consistent with the built-in commands.
+
+
+Adding arguments
+^^^^^^^^^^^^^^^^
+
+Override ``_init_parser`` to add argparse arguments:
+
+.. code-block:: python
+
+   @classmethod
+   def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+       parser = super()._init_parser(name)
+       parser.add_argument("-n", "--limit", type=int, default=10)
+       return parser
+
+Access them as ``self.args.limit`` in ``_call``.  If the user passes
+invalid arguments, argparse raises a ``SystemExit`` which sdb catches and
+converts to a ``CommandArgumentsError`` -- the REPL stays alive.
+
+
+The ``@InputHandler`` decorator
+-------------------------------
+
+``InputHandler`` is used on methods of ``Locator`` subclasses to register
+type-specific handlers.  When a Locator receives input, it dispatches to
+the matching handler based on the input object's C type.
+
+.. code-block:: python
+
+   class SpaLocator(sdb.Locator, sdb.PrettyPrinter):
+       names = ["spa"]
+       output_type = "spa_t *"
+       load_on = [sdb.Kernel()]
+
+       def no_input(self):
+           # Called when the command starts a pipeline
+           ...
+
+       @sdb.InputHandler("vdev_t *")
+       def from_vdev(self, vdev):
+           """Given a vdev, yield its parent spa."""
+           yield vdev.vdev_spa
+
+Dispatch order when a Locator receives an object:
+
+1. Check ``@InputHandler``-decorated methods for a type match.
+2. If the object already matches ``output_type``, pass it through.
+3. Try the ``walk`` dispatch to iterate the object and cast each element
+   to ``output_type``.
+4. Raise ``CommandError`` if nothing matches.
+
+
+Hybrid Locator / PrettyPrinter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A class can inherit from both ``Locator`` and ``PrettyPrinter``.  The
+behavior adapts based on position in the pipeline:
+
+* **First**: calls ``no_input()`` to locate objects, then pretty-prints.
+* **Last**: receives input, locates matching objects, then pretty-prints.
+* **Middle**: locates objects and passes them downstream (no printing).
+
+
+The ``pre_cmd_hook`` mechanism
+------------------------------
+
+``sdb.start()`` accepts an optional ``pre_cmd_hook`` callable.  It is
+invoked with no arguments immediately before each REPL command is evaluated.
+
+.. code-block:: python
+
+   sdb.start(prog, pre_cmd_hook=my_refresh_fn)
+
+The hook is **not** called for meta-commands (``%session``,
+``%load-commands``).
+
+Use cases:
+
+* **Cache invalidation**: bump a generation counter so stale pages are
+  re-fetched (this is what GhostWire does).
+* **Transport reconnection**: re-establish a connection if it dropped.
+* **Telemetry**: count commands, measure latency.
+
+
+Command registration internals
+------------------------------
+
+The registration flow:
+
+1. When Python imports a module containing a ``Command`` subclass,
+   ``__init_subclass__`` calls ``add_command(cls)`` which adds the class to
+   the ``all_commands`` set.
+
+2. ``register_commands()`` iterates ``all_commands`` and checks each class's
+   ``load_on`` list against the current runtime (kernel or userland).  If
+   appropriate, it calls ``register_command(name, cls)`` for each name in
+   ``cls.names``.
+
+3. ``register_command`` adds the name→class mapping to
+   ``registered_commands`` and also registers Walkers and PrettyPrinters in
+   their respective global lookup tables.
+
+This means:
+
+* Commands are discovered at import time (step 1).
+* Commands are activated at registration time (step 2).
+* ``load_external_commands()`` handles step 1 for files outside the sdb
+  package.  You must call ``register_commands()`` afterward to activate them.
+* ``sdb.start()`` calls both ``load_external_commands`` and
+  ``register_commands`` for you.
+
+
+Type canonicalization
+---------------------
+
+sdb normalises C types to handle typedefs, qualifiers, and pointer
+variations.  The key helpers:
+
+``type_canonicalize(type)``
+   Strip all typedefs from a ``drgn.Type`` and return the underlying type.
+
+``type_canonical_name(type)``
+   Return the canonical name string after stripping typedefs.
+
+``type_canonicalize_name(name)``
+   Like ``type_canonical_name`` but accepts a name string.  Looks up the
+   type via drgn first.
+
+``type_equals(a, b)``
+   Compare two types after canonicalization.
+
+These are used internally by the pipeline's auto-coercion logic and by
+Walkers and PrettyPrinters when matching input types.  If you write a
+command that needs to compare types, prefer these over raw ``==`` on
+``drgn.Type`` objects.
+
+
+Error handling
+--------------
+
+sdb defines an error hierarchy rooted at ``sdb.Error``.  Commands should
+raise these rather than printing error messages and returning:
+
+``CommandError(command_name, message)``
+   General runtime error.  The REPL prints it and returns to the prompt.
+
+``SymbolNotFoundError(command_name, symbol)``
+   A symbol name could not be resolved.
+
+``CommandInvalidInputError(command_name, input_type, expected_type)``
+   Type mismatch on input.
+
+The REPL catches ``sdb.Error`` and prints ``err.text`` without a traceback.
+Unexpected exceptions (anything not derived from ``sdb.Error``) trigger a
+full traceback with a link to the issue tracker.
+
+
+Testing commands
+----------------
+
+sdb uses pytest with a two-tier test strategy:
+
+**Unit tests** (``tests/unit/``)
+   Mock the drgn program and test command logic in isolation.  These run
+   without any crash dump.
+
+**Integration tests** (``tests/integration/``)
+   Run commands against real crash dumps and compare output to reference
+   files.  These require downloading test dumps first.
+
+When contributing a new command, add at least a unit test that exercises the
+core logic.  If the command depends on kernel data structures, add an
+integration test with expected output.
+
+Run the test suite:
+
+.. code-block:: bash
+
+   pip install -e ".[dev]"
+   pytest -v tests/unit

--- a/docs/tutorials/external-commands.rst
+++ b/docs/tutorials/external-commands.rst
@@ -1,0 +1,276 @@
+Creating and loading external commands
+======================================
+
+sdb is designed to be extended.  You can write your own commands as Python
+modules, load them at startup or at runtime, and they integrate seamlessly
+with the pipeline, tab completion, and ``help`` system.
+
+.. contents:: In this tutorial
+   :local:
+   :depth: 2
+
+
+Anatomy of a command
+--------------------
+
+An sdb command is a Python class that inherits from :class:`sdb.Command` (or
+one of its subclasses) and declares a ``names`` list.  When the module is
+imported, ``Command.__init_subclass__`` automatically registers the class.
+
+Here is a minimal command that prints the ``comm`` field of every
+``task_struct`` it receives:
+
+.. code-block:: python
+
+   from typing import ClassVar, Iterable, List, Optional
+
+   import drgn
+   import sdb
+
+
+   class TaskName(sdb.Command):
+       """Print the name of each task."""
+
+       names: ClassVar[List[str]] = ["task_name"]
+       input_type: ClassVar[Optional[str]] = "struct task_struct *"
+       load_on: ClassVar[List[sdb.Runtime]] = [sdb.Kernel()]
+
+       def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+           for task in objs:
+               print(task.comm.string_().decode())
+           return iter(())
+
+Key attributes:
+
+``names``
+   A list of strings.  Each string becomes a name you can type in the REPL.
+   The first name is the primary name used in help text.
+
+``input_type``
+   The C type this command expects as input (as a string).  Set to ``None``
+   if the command accepts any type.  When a pointer type is declared, sdb
+   will automatically cast ``void *`` inputs and take the address of
+   non-pointer objects of the matching type.
+
+``load_on``
+   Controls when the command is registered.  Use ``sdb.Kernel()`` for
+   kernel-only commands, ``sdb.Userland()`` for userland, or ``sdb.All()``
+   to always register.  You can also use ``sdb.Module("zfs")`` or
+   ``sdb.Library("libfoo")`` for finer control (these currently resolve to
+   kernel and userland respectively until drgn gains module enumeration).
+
+
+Choosing a base class
+---------------------
+
+sdb provides several base classes; pick the one that matches your command's
+purpose:
+
+:class:`sdb.Command`
+   Generic base.  Implement ``_call(self, objs)`` and yield drgn objects
+   or print output.  For a simple example, see
+   `count.py <https://github.com/sdimitro/sdb/blob/master/sdb/commands/count.py>`_.
+
+:class:`sdb.SingleInputCommand`
+   Like ``Command``, but calls ``_call_one(self, obj)`` for each input
+   object independently.  If one object triggers a ``FaultError``, the
+   error is printed and processing continues with the next object.  See
+   `member.py <https://github.com/sdimitro/sdb/blob/master/sdb/commands/member.py>`_
+   for an example.
+
+:class:`sdb.Walker`
+   Iterate over a data structure.  Declare ``input_type`` and implement
+   ``walk(self, obj)`` to yield each element.  For a real example, see the
+   ``linux_list`` walker in
+   `linked_lists.py <https://github.com/sdimitro/sdb/blob/master/sdb/commands/linux/linked_lists.py>`_
+   or the AVL tree walker in
+   `avl.py <https://github.com/sdimitro/sdb/blob/master/sdb/commands/spl/avl.py>`_.
+
+:class:`sdb.PrettyPrinter`
+   Human-readable output.  Declare ``input_type`` and implement
+   ``pretty_print(self, objs)``.  When the command is last in a pipeline
+   it prints; otherwise it yields objects.
+
+:class:`sdb.Locator`
+   Find objects of a given type.  Declare ``output_type`` and implement
+   ``no_input(self)`` for when the command starts a pipeline.  Locators
+   can also be combined with ``PrettyPrinter`` to create commands that
+   both locate and display objects.  The ``stacks`` command in
+   `stacks.py <https://github.com/sdimitro/sdb/blob/master/sdb/commands/linux/stacks.py>`_
+   is a good example of a hybrid Locator + PrettyPrinter, and the ``spa``
+   command in
+   `spa.py <https://github.com/sdimitro/sdb/blob/master/sdb/commands/zfs/spa.py>`_
+   shows Locator with ``@InputHandler`` dispatch.
+
+
+Example: a Walker
+-----------------
+
+.. code-block:: python
+
+   from typing import ClassVar, Iterable, List, Optional
+
+   import drgn
+   import sdb
+
+
+   class MyListWalker(sdb.Walker):
+       """Walk a custom linked list."""
+
+       names: ClassVar[List[str]] = ["my_list"]
+       input_type: ClassVar[Optional[str]] = "struct my_list_head *"
+       load_on: ClassVar[List[sdb.Runtime]] = [sdb.Module("my_module")]
+
+       def walk(self, obj: drgn.Object) -> Iterable[drgn.Object]:
+           node = obj.first
+           while not sdb.is_null(node):
+               yield node
+               node = node.next
+
+Once loaded, this walker is available through the ``walk`` dispatch command::
+
+   sdb> addr some_global | walk
+
+
+Example: a Locator + PrettyPrinter
+-----------------------------------
+
+.. code-block:: python
+
+   from typing import ClassVar, Iterable, List, Optional
+
+   import drgn
+   import sdb
+
+
+   class GizmoInfo(sdb.Locator, sdb.PrettyPrinter):
+       """Locate and pretty-print gizmo_t objects."""
+
+       names: ClassVar[List[str]] = ["gizmo"]
+       input_type: ClassVar[Optional[str]] = "gizmo_t *"
+       output_type: ClassVar[Optional[str]] = "gizmo_t *"
+       load_on: ClassVar[List[sdb.Runtime]] = [sdb.Kernel()]
+
+       def no_input(self) -> Iterable[drgn.Object]:
+           head = sdb.get_object("gizmo_list")
+           node = head.first
+           while not sdb.is_null(node):
+               yield node
+               node = node.next
+
+       def pretty_print(self, objs: Iterable[drgn.Object]) -> None:
+           for obj in objs:
+               name = obj.name.string_().decode()
+               print(f"{hex(obj.value_())}  {name}")
+
+Usage::
+
+   sdb> gizmo
+   0xffff...  widget-alpha
+   0xffff...  widget-beta
+
+   sdb> gizmo | count
+   (unsigned long long)2
+
+
+Adding arguments
+----------------
+
+Override ``_init_parser`` to add argparse arguments:
+
+.. code-block:: python
+
+   import argparse
+
+   class TaskName(sdb.Command):
+       names: ClassVar[List[str]] = ["task_name"]
+       input_type: ClassVar[Optional[str]] = "struct task_struct *"
+       load_on: ClassVar[List[sdb.Runtime]] = [sdb.Kernel()]
+
+       @classmethod
+       def _init_parser(cls, name: str) -> argparse.ArgumentParser:
+           parser = super()._init_parser(name)
+           parser.add_argument("-u", "--upper", action="store_true",
+                               help="uppercase the output")
+           return parser
+
+       def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+           for task in objs:
+               name = task.comm.string_().decode()
+               if self.args.upper:
+                   name = name.upper()
+               print(name)
+           return iter(())
+
+The arguments are parsed automatically and available as ``self.args``.
+Users see them in ``help``::
+
+   sdb> help task_name
+   SUMMARY
+       task_name [-h] [-u]
+   ...
+
+
+Loading external commands
+-------------------------
+
+There are four ways to load your commands:
+
+At startup via CLI flag
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   sudo sdb --load-commands /path/to/my/commands
+
+The path can be a single ``.py`` file or a directory (all ``.py`` files
+are loaded recursively, skipping ``__init__.py`` and friends).  The flag
+can be repeated.
+
+At startup via environment variable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   export SDB_COMMANDS_PATH="/path/one:/path/two"
+   sudo sdb
+
+Colon-separated, just like ``$PATH``.
+
+At runtime from the REPL
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   sdb> %load-commands /path/to/my/commands
+   Loaded 2 command(s): task_name, gizmo
+
+Tab completion is automatically refreshed after loading.
+
+From the library API
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   import sdb
+
+   sdb.start(prog, command_paths=["/path/to/my/commands"])
+
+Or load after initialization:
+
+.. code-block:: python
+
+   sdb.load_external_commands("/path/to/my/commands")
+   sdb.register_commands()
+
+
+File layout tips
+----------------
+
+* Keep one command per file, or group related commands in one file.
+* Do **not** name your file ``__init__.py`` or start it with ``__`` -- these
+  are skipped by the loader.
+* Imports of ``sdb`` and ``drgn`` work normally -- sdb is already in the
+  Python path.
+* If your commands have heavy dependencies, put them behind lazy imports
+  inside ``_call`` to avoid slowing down startup.

--- a/docs/tutorials/library-usage.rst
+++ b/docs/tutorials/library-usage.rst
@@ -1,0 +1,275 @@
+Using sdb as a library
+======================
+
+sdb is not just a standalone debugger -- it exposes a Python API that lets
+you embed an sdb REPL inside your own tool or run sdb pipelines
+programmatically.  A real-world example of this is GhostWire, a remote
+kernel introspection tool for NVIDIA BlueField DPUs that builds a
+``drgn.Program`` backed by TCP (or RDMA) memory reads and then drops the
+user into sdb.
+
+.. contents:: In this tutorial
+   :local:
+   :depth: 2
+
+
+The ``sdb.start()`` entry point
+--------------------------------
+
+The simplest integration is to hand sdb a ``drgn.Program`` and let it run
+the REPL:
+
+.. code-block:: python
+
+   import drgn
+   import sdb
+
+   prog = drgn.Program()
+   prog.set_kernel()
+   prog.load_default_debug_info()
+
+   sdb.start(prog)
+
+``sdb.start()`` accepts several optional parameters:
+
+.. code-block:: python
+
+   sdb.start(
+       prog,
+       command_paths=["/path/to/my/commands"],  # extra command directories
+       prompt="mydb> ",                          # custom REPL prompt
+       pre_cmd_hook=my_refresh_fn,               # called before each command
+       eval_cmd="stacks | count",                # run one command and exit
+       history_file="~/.mydb_history",           # readline history path
+   )
+
+
+Running pipelines programmatically
+-----------------------------------
+
+For scripting and automation, use ``sdb.invoke()`` to execute a pipeline
+and iterate over the results:
+
+.. code-block:: python
+
+   import sdb
+
+   # After sdb.start() has been called or the target has been
+   # set up manually (see "Manual setup" below)
+
+   for obj in sdb.invoke([], "spa | member spa_name"):
+       name = obj.string_().decode()
+       print(f"Pool: {name}")
+
+``invoke`` returns a generator of ``drgn.Object`` values.  The first
+argument is the initial input to the pipeline (an empty list to start from
+scratch).
+
+You can also build and execute pipelines at a lower level:
+
+.. code-block:: python
+
+   from sdb.pipeline import execute_pipeline
+   from sdb.command import get_registered_commands
+
+   cmds = get_registered_commands()
+   pipeline = [cmds["spa"]([], "spa"), cmds["count"]([], "count")]
+   pipeline[0].isfirst = True
+   pipeline[-1].islast = True
+
+   for obj in execute_pipeline([], pipeline):
+       print(obj)
+
+
+The ``pre_cmd_hook`` pattern
+----------------------------
+
+Many tools that embed sdb maintain caches or transport state that must be
+refreshed between commands.  The ``pre_cmd_hook`` parameter solves this.
+
+It accepts any callable with no arguments.  sdb calls it immediately before
+evaluating each REPL command (but **not** for meta-commands like
+``%session``).
+
+A typical pattern for remote debuggers:
+
+.. code-block:: python
+
+   sdb.start(
+       prog,
+       command_paths=[sdb_commands_dir],
+       prompt="sdb[remote]> ",
+       pre_cmd_hook=transport.bump_generation,
+   )
+
+The effect: each new command sees fresh host memory, while reads within a
+single command's execution are cached for performance.
+
+Typical use cases:
+
+* Invalidating a memory cache so each command sees fresh data.
+* Reconnecting a transport layer if the connection was dropped.
+* Refreshing authentication tokens for a remote target.
+* Logging or telemetry (count commands, measure latency).
+
+
+Loading custom commands
+-----------------------
+
+Pass directories or files containing your ``sdb.Command`` subclasses via
+``command_paths``:
+
+.. code-block:: python
+
+   sdb.start(prog, command_paths=[
+       "/opt/mytools/sdb_commands",
+       "/home/me/debug/my_walkers.py",
+   ])
+
+You can also load commands after initialization:
+
+.. code-block:: python
+
+   sdb.load_external_commands("/opt/mytools/sdb_commands")
+   sdb.register_commands()
+
+See :doc:`external-commands` for how to write custom commands.
+
+
+Manual setup (without ``sdb.start()``)
+---------------------------------------
+
+If you need tighter control -- for example to run pipelines without starting
+a REPL -- you can set up the sdb runtime manually:
+
+.. code-block:: python
+
+   import drgn
+   import sdb
+   import sdb.target as sdb_target
+
+   prog = drgn.Program()
+   prog.set_kernel()
+   prog.load_default_debug_info()
+
+   sdb_target.set_prog(prog)
+   sdb_target.set_thread(next(prog.threads()).object)
+   sdb_target.set_frame(-1)
+
+   sdb.register_commands()
+
+   # Now you can call invoke() directly
+   for obj in sdb.invoke([], "slabs | head 3"):
+       print(obj)
+
+
+Real-world example: GhostWire
+-------------------------------
+
+GhostWire is a remote Linux kernel introspection tool that runs on an
+NVIDIA BlueField DPU.  It reads the host machine's physical memory over the
+network (using TCP or RDMA), constructs a ``drgn.Program`` from those remote
+reads, and then offers the user either a plain drgn REPL or a full sdb
+session.
+
+The interesting part is how the remote ``drgn.Program`` is built.
+GhostWire's transport layer provides a ``read_phys(address, size)`` function
+that fetches physical memory from the host over the network.  The program
+construction looks roughly like this:
+
+.. code-block:: python
+
+   import drgn
+
+   # 1. Read vmcoreinfo from the host (needed for KASLR and type info)
+   vmcoreinfo = transport.read_phys(host.vmcoreinfo_phys, host.vmcoreinfo_size)
+
+   # 2. Create a Program with the host's platform and vmcoreinfo
+   prog = drgn.Program(
+       platform=drgn.Platform(drgn.Architecture.X86_64),
+       vmcoreinfo=vmcoreinfo,
+   )
+
+   # 3. Register physical memory segments backed by the network transport
+   read_fn = transport.make_drgn_read_fn()
+   for r in host.ranges:
+       prog.add_memory_segment(
+           address=r.start,
+           size=r.end - r.start,
+           read_fn=read_fn,
+           physical=True,
+       )
+
+   # 4. Initialize kernel page-table walking and KASLR relocation
+   prog.set_linux_kernel_custom(vmcoreinfo=vmcoreinfo, is_live=True)
+
+   # 5. Load debug info (vmlinux with DWARF)
+   prog.main_module("vmlinux", create=True).try_file("/path/to/vmlinux")
+
+At this point ``prog`` is a fully functional ``drgn.Program`` that resolves
+types, walks page tables, and reads kernel memory -- all transparently
+backed by network reads.  The user doesn't need to know or care that the
+data comes from a remote machine.
+
+The sdb integration is then just a thin bridge:
+
+.. code-block:: python
+
+   import os
+   import sdb
+
+   def run_sdb(prog, transport):
+       sdb_commands_dir = os.path.join(
+           os.path.dirname(__file__), "sdb_commands"
+       )
+       sdb.start(
+           prog,
+           command_paths=[sdb_commands_dir],
+           prompt="sdb[gw]> ",
+           pre_cmd_hook=transport.bump_generation,
+       )
+
+Key points:
+
+* **``command_paths``** loads GhostWire-specific commands from a directory
+  next to the bridge module.
+* **``pre_cmd_hook``** bumps the transport cache generation so each REPL
+  command sees fresh host memory.  GhostWire uses a generation-based page
+  cache: reads within a single command are cached (for fast page-table
+  walks), but the cache is invalidated between commands.
+* **``prompt``** is customized to ``sdb[gw]>`` so the user knows they are
+  in a GhostWire sdb session.
+* sdb is an **optional dependency** -- GhostWire imports it lazily and only
+  when the user passes ``--sdb``.
+
+GhostWire also adds its own domain-specific commands.  For example, a
+command to print the host's firmware version:
+
+.. code-block:: python
+
+   from typing import ClassVar, Iterable, List
+
+   import drgn
+   import sdb
+
+
+   class GwFirmwareVersion(sdb.Command):
+       """Print the firmware version from the kernel command line."""
+
+       names: ClassVar[list[str]] = ["gw_firmware_version"]
+       load_on: ClassVar[list[sdb.Runtime]] = [sdb.Kernel()]
+
+       def _call(self, objs: Iterable[drgn.Object]) -> Iterable[drgn.Object]:
+           cmdline = sdb.get_object("saved_command_line").string_().decode()
+           for part in cmdline.split():
+               if part.startswith("fw_ver="):
+                   print(part.split("=", 1)[1])
+                   break
+           else:
+               print("firmware version not found in command line")
+           return iter(())
+
+This demonstrates how an embedding tool can expose its own domain-specific
+commands through sdb's REPL while reusing the entire sdb infrastructure --
+pipelines, tab completion, help, recording, and everything else come for
+free.

--- a/docs/tutorials/recording.rst
+++ b/docs/tutorials/recording.rst
@@ -1,0 +1,241 @@
+Recording and replaying sessions
+================================
+
+sdb can record the memory accesses made during a debugging session into a
+portable vmcore file.  This file can later be replayed on any machine --
+without the original crash dump, live kernel, or even root access -- making
+it easy to share debugging context with colleagues or revisit a session
+offline.
+
+.. contents:: In this tutorial
+   :local:
+   :depth: 2
+
+
+How it works
+------------
+
+When recording is active, sdb intercepts every memory read that drgn performs
+and stores the data in a sparse memory buffer.  Reads are "fat-aligned" to
+256-byte boundaries so that surrounding memory (like struct fields you haven't
+explicitly accessed yet) is captured too.
+
+When recording stops, the buffer is written out as a standard ELF64 vmcore
+(or optionally a kdump-compressed file) using `kdumpling
+<https://pypi.org/project/kdumpling/>`_.  The vmcore includes:
+
+* All memory segments that were read during the session.
+* The kernel's ``vmcoreinfo`` (needed for KASLR relocation and type info).
+* An SDB-specific ELF note with session metadata (timestamp, kernel release,
+  etc.).
+
+Because the output is a real vmcore, it can be loaded by drgn, crash, or any
+other tool that reads ELF core dumps.
+
+
+Starting a recording
+--------------------
+
+From the command line
+^^^^^^^^^^^^^^^^^^^^^
+
+Pass ``--record`` when launching sdb::
+
+   $ sudo sdb --record my-session
+
+sdb will start normally and save the recording to
+``my-session.vmcore.recorded`` when you exit (or Ctrl-D).
+
+From the REPL
+^^^^^^^^^^^^^
+
+Start recording at any time during a session::
+
+   sdb> %session record my-session
+   Recording started. Output: my-session.vmcore.recorded
+
+Now run whatever commands you need.  Every memory access they trigger will
+be captured.
+
+
+Stopping a recording
+--------------------
+
+::
+
+   sdb> %session stop
+   Recording stopped.
+   Saved to: my-session.vmcore.recorded
+     Memory segments: 1842
+     Memory size: 471552 bytes
+
+If you started with ``--record``, the recording also stops automatically
+when the REPL exits.
+
+
+Checking recording status
+-------------------------
+
+::
+
+   sdb> %session status
+   Recording to: my-session.vmcore.recorded
+     Format: elf
+     Memory segments: 1842
+     Memory size: 471552 bytes
+
+
+Capturing extra data
+--------------------
+
+By default, only memory accessed by the commands you run is recorded.  Two
+meta-commands let you explicitly pull in additional data:
+
+``%session snapshot``
+^^^^^^^^^^^^^^^^^^^^^
+
+Capture an object and (optionally) follow its pointers::
+
+   sdb> %session snapshot jiffies
+   Snapshot captured: jiffies
+     Memory segments: 1843
+     Memory size: 471808 bytes
+
+   sdb> %session snapshot init_task --depth 2
+
+The ``--depth`` flag controls how many levels of pointer indirection to
+follow (default 1).
+
+``%session record-memory``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Capture a raw memory region by address and size::
+
+   sdb> %session record-memory 0xffffffff97205000 4096
+   Recorded 4096 bytes at 0xffffffff97205000
+
+An optional ``--physical`` flag reads physical memory instead of virtual.
+
+
+Configuring the output format
+-----------------------------
+
+By default, recordings are saved as uncompressed ELF vmcores.  For large
+sessions you can switch to kdump format with compression::
+
+   sdb> %session config format kdump
+   Output format set to: kdump
+     Compression: zlib
+
+   sdb> %session config compression zstd
+   Compression set to: zstd
+
+   sdb> %session config compression-level 3
+   Compression level set to: 3
+
+Run ``%session config`` with no arguments to see the current settings.
+
+Supported compression algorithms (kdump format only): ``none``, ``zlib``,
+``lzo``, ``snappy``, ``zstd``.
+
+
+Replaying a recorded session
+-----------------------------
+
+On the same machine or any other machine with sdb and the matching debug
+symbols installed::
+
+   $ sdb --replay my-session.vmcore.recorded -s /path/to/vmlinux
+
+sdb opens the vmcore the same way it opens a crash dump -- no special
+mode, no root access required.  The only limitation is that you can only
+access memory that was captured during the original session.  Accessing
+anything else will produce a ``FaultError``.
+
+You can combine ``--replay`` with ``-e`` for scripted analysis::
+
+   $ sdb --replay my-session.vmcore.recorded -s /path/to/vmlinux \
+       -e "stacks -t D"
+
+
+Recording whole memory regions
+------------------------------
+
+Sometimes you know you will need a particular memory region during replay
+but haven't accessed it through normal commands yet.  The
+``%session record-memory`` meta-command lets you capture arbitrary virtual
+(or physical) address ranges into the recording::
+
+   sdb> %session record-memory 0xffffffff97200000 0x10000
+   Recorded 65536 bytes at 0xffffffff97200000
+
+   sdb> %session record-memory 0x100000 0x1000 --physical
+   Recorded 4096 bytes at 0x100000 (physical)
+
+This is the low-level building block that ``%session snapshot`` builds on.
+Use it when you need precise control over what gets captured -- for example,
+recording a device's MMIO region or a specific page-table page.
+
+
+Practical use cases
+-------------------
+
+Sharing debugging context
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When triaging a production issue, one engineer can record a session and
+share the ``.vmcore.recorded`` file.  A colleague can replay it without
+needing access to the original system or crash dump -- they just need
+the debug symbols.
+
+Live dumps (local and remote)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Recording works on live kernels, not just crash dumps.  This means you can
+create a "live dump" -- a lightweight snapshot of the kernel state you care
+about -- without crashing the machine or taking a full memory dump.
+
+This is especially powerful when sdb is embedded in a remote debugger.  A
+tool like GhostWire can read a remote host's physical memory over the
+network, and sdb's recording captures exactly the memory regions touched
+during the remote session.  The resulting vmcore is fully self-contained
+and can be replayed locally without any network access to the original host.
+
+Offline analysis
+^^^^^^^^^^^^^^^^
+
+Record a session on a live system, then replay it later on your laptop::
+
+   $ sudo sdb --record quick-look
+   sdb> stacks
+   sdb> slabs
+   sdb> spa | pp
+   ^D
+   Recording saved to: quick-look.vmcore.recorded
+
+   # later, on your laptop
+   $ sdb --replay quick-look.vmcore.recorded -s ./vmlinux
+
+Test cases and regression dumps
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Recorded sessions make excellent test fixtures.  When you encounter a bug
+or an interesting kernel state, record a session that exercises it.  The
+resulting vmcore becomes a deterministic, portable test input that can be
+replayed in CI without needing the original hardware or a live kernel::
+
+   $ sudo sdb --record regression-zfs-arc -e "arc"
+
+Over time you build a library of recorded states covering edge cases that
+would be difficult to reproduce on demand.  sdb's own integration tests
+use crash dumps in exactly this way.
+
+CI and automation
+^^^^^^^^^^^^^^^^^
+
+Use ``-e`` with ``--record`` to script a recording::
+
+   $ sudo sdb --record nightly-check -e "stacks -t D | count"
+
+The vmcore is saved even when using ``-e``, so you can archive it alongside
+the command output for later inspection.

--- a/docs/tutorials/stacks.rst
+++ b/docs/tutorials/stacks.rst
@@ -1,0 +1,225 @@
+Using ``stacks``
+================
+
+The ``stacks`` command (alias ``stack``) is one of the most frequently used
+commands when debugging Linux kernels.  It prints aggregated stack traces for
+kernel threads, making it easy to spot patterns, find blocked threads, and
+diagnose hangs.
+
+.. contents:: In this tutorial
+   :local:
+   :depth: 2
+
+
+Basic usage
+-----------
+
+With no arguments, ``stacks`` iterates over every ``task_struct`` in the
+system, groups threads by identical call stacks, and prints them sorted by
+frequency (most common first)::
+
+   sdb> stacks
+   TASK_STRUCT        STATE             COUNT
+   ==========================================
+   0xffff9521bb3c3b80 IDLE                394
+                     __schedule+0x24e
+                     schedule+0x2c
+                     worker_thread+0xba
+                     kthread+0x121
+                     ret_from_fork+0x35
+
+   0xffff9521bb3cbb80 INTERRUPTIBLE       384
+                     __schedule+0x24e
+                     schedule+0x2c
+                     smpboot_thread_fn+0x166
+                     kthread+0x121
+                     ret_from_fork+0x35
+   ...
+
+
+Reading the output
+------------------
+
+Each group has a header and a stack trace:
+
+**TASK_STRUCT**
+   The address of one representative ``struct task_struct *`` for this group.
+   You can pipe it into other commands (e.g. ``member comm`` to get the
+   thread name).
+
+**STATE**
+   The scheduler state of the threads in this group.  Common values:
+
+================= ==============================================
+State             Meaning
+================= ==============================================
+RUNNING           On a CPU or in the run queue
+INTERRUPTIBLE     Sleeping, wakes on signals or events
+UNINTERRUPTIBLE   Sleeping, does not wake on signals (D state)
+IDLE              Idle kernel worker
+STOPPED           Stopped by a signal (SIGSTOP)
+ZOMBIE            Exited, waiting for parent to reap
+PARKED            Parked kthread (cpu hotplug)
+================= ==============================================
+
+**COUNT**
+   How many threads share this exact (state, stack) combination.  A high
+   count for an UNINTERRUPTIBLE stack is a strong signal that something is
+   blocked.
+
+The stack trace itself lists frames from the sleep/block point at the top
+down to the entry point at the bottom (``ret_from_fork`` for kthreads,
+``entry_SYSCALL_64`` for syscalls).
+
+
+Filtering by thread state
+--------------------------
+
+Use ``-t`` to show only threads in a particular state::
+
+   sdb> stacks -t RUNNING
+   TASK_STRUCT        STATE             COUNT
+   ==========================================
+   0xffff95214ff31dc0 RUNNING               1
+
+   sdb> stacks -t UNINTERRUPTIBLE
+
+You can also use the single-character shortcuts from ``ps(1)``: ``R``, ``S``,
+``D``, ``T``, ``I``, etc.::
+
+   sdb> stacks -t D
+
+
+Filtering by function
+---------------------
+
+Use ``-c`` to show only threads whose stack contains a specific function::
+
+   sdb> stacks -c l2arc_feed_thread
+   TASK_STRUCT        STATE             COUNT
+   ==========================================
+   0xffff9521b3f43b80 INTERRUPTIBLE         1
+                     __schedule+0x24e
+                     schedule+0x2c
+                     schedule_timeout+0x15d
+                     __cv_timedwait_common+0xdf
+                     __cv_timedwait_sig+0x16
+                     l2arc_feed_thread+0x66
+                     thread_generic_wrapper+0x74
+                     kthread+0x121
+                     ret_from_fork+0x35
+
+
+Filtering by kernel module
+--------------------------
+
+Use ``-m`` to show only threads that have at least one frame from a given
+kernel module::
+
+   sdb> stacks -m zfs
+   TASK_STRUCT        STATE             COUNT
+   ==========================================
+   0xffff952130515940 INTERRUPTIBLE         1
+                     __schedule+0x24e
+                     schedule+0x2c
+                     cv_wait_common+0x11f
+                     __cv_wait_sig+0x15
+                     zthr_procedure+0x51
+                     thread_generic_wrapper+0x74
+                     kthread+0x121
+                     ret_from_fork+0x35
+   ...
+
+
+Listing all threads per stack
+-----------------------------
+
+By default only one representative ``task_struct`` address is shown per
+group.  Use ``-a`` to list every thread::
+
+   sdb> stacks -a -t IDLE
+   TASK_STRUCT        STATE
+   ==========================================
+   0xffff9521bb3c3b80 IDLE
+   0xffff9521bb3c7b80
+   0xffff9521bb3cbb80
+   ...
+
+
+Composing with other commands
+-----------------------------
+
+Because ``stacks`` is both a **Locator** and a **PrettyPrinter**, it can
+appear anywhere in a pipeline:
+
+Count ZFS threads::
+
+   sdb> stacks -m zfs | count
+   (unsigned long long)12
+
+Get the ``comm`` (name) of all uninterruptible threads::
+
+   sdb> stacks -t D | member comm
+
+Feed specific threads into ``stack``::
+
+   sdb> threads | filter obj.comm == "zthr_procedure" | stack
+
+Pipe to the shell to post-process::
+
+   sdb> stacks ! grep -c "UNINTERRUPTIBLE"
+
+
+Practical scenarios
+-------------------
+
+Diagnosing a hang
+^^^^^^^^^^^^^^^^^
+
+When a system is unresponsive, start with::
+
+   sdb> stacks -t D
+
+Every UNINTERRUPTIBLE stack is a thread waiting for something (I/O, a lock,
+etc.).  If many threads share the same stack, that common point is likely
+the bottleneck.  Follow up with ``-c <function>`` to narrow down.
+
+Crash dump triage
+^^^^^^^^^^^^^^^^^
+
+For crash dumps, find the panicking thread first::
+
+   sdb> crashed_thread
+   TASK_STRUCT        STATE             COUNT
+   ==========================================
+   0xffff8f15d7333d00 RUNNING               1
+                     __crash_kexec+0x9d
+                     ...
+
+Then look at the broader picture with ``stacks`` to see what else was
+happening at the time of the crash.
+
+Slow or stuck I/O
+^^^^^^^^^^^^^^^^^^
+
+A high thread count on an I/O-related stack trace is a strong indicator that
+I/Os are either hanging or completing too slowly.  For example, if you see
+dozens of threads piled up in a block-layer or storage-driver wait path,
+that subsystem is likely the bottleneck.  Combine ``-m`` with ``-c`` to
+confirm::
+
+   sdb> stacks -m nvme -c nvme_queue_rq
+
+If the count keeps growing across successive ``stacks`` invocations on a
+live system, the I/Os are not completing at all (hung).  If the count is
+high but stable, throughput is simply too low for the workload.
+
+Finding threads from a specific subsystem
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Combine ``-m`` and ``-c`` to zero in::
+
+   sdb> stacks -m zfs -c spa_sync
+
+This shows only threads in the ZFS module whose stack includes
+``spa_sync``.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+sphinx>=7.0
+furo
+sphinx-copybutton


### PR DESCRIPTION
Add Sphinx-based documentation with furo theme covering quickstart, tutorials (stacks, session recording, external commands, library usage), and reference material (concepts, API, command reference, developer notes).