### PR TITLE
docs: remove inline table-of-contents directives

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -4,11 +4,6 @@ Public API reference
 This page documents the public Python API exported by the ``sdb`` package.
 Everything listed here is part of ``sdb.__all__`` and is considered stable.
 
-.. contents:: On this page
-   :local:
-   :depth: 2
-
-
 Entry point
 -----------
 

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -4,11 +4,6 @@ Command reference
 This page lists every built-in sdb command, grouped by domain.  Use
 ``help <command>`` inside the REPL for full details and examples.
 
-.. contents:: On this page
-   :local:
-   :depth: 2
-
-
 Core commands
 -------------
 

--- a/docs/reference/concepts.rst
+++ b/docs/reference/concepts.rst
@@ -5,11 +5,6 @@ This page explains the key abstractions that make sdb tick.  Understanding
 these concepts will help you read sdb output, compose pipelines effectively,
 and write your own commands.
 
-.. contents:: On this page
-   :local:
-   :depth: 2
-
-
 The pipeline
 ------------
 

--- a/docs/reference/developer-notes.rst
+++ b/docs/reference/developer-notes.rst
@@ -4,11 +4,6 @@ Developer notes
 This page covers the internals you need to know when writing sdb commands
 or embedding sdb in your own tools.
 
-.. contents:: On this page
-   :local:
-   :depth: 2
-
-
 Writing a new command
 ---------------------
 

--- a/docs/tutorials/external-commands.rst
+++ b/docs/tutorials/external-commands.rst
@@ -5,11 +5,6 @@ sdb is designed to be extended.  You can write your own commands as Python
 modules, load them at startup or at runtime, and they integrate seamlessly
 with the pipeline, tab completion, and ``help`` system.
 
-.. contents:: In this tutorial
-   :local:
-   :depth: 2
-
-
 Anatomy of a command
 --------------------
 

--- a/docs/tutorials/library-usage.rst
+++ b/docs/tutorials/library-usage.rst
@@ -8,11 +8,6 @@ kernel introspection tool for NVIDIA BlueField DPUs that builds a
 ``drgn.Program`` backed by TCP (or RDMA) memory reads and then drops the
 user into sdb.
 
-.. contents:: In this tutorial
-   :local:
-   :depth: 2
-
-
 The ``sdb.start()`` entry point
 --------------------------------
 

--- a/docs/tutorials/recording.rst
+++ b/docs/tutorials/recording.rst
@@ -7,11 +7,6 @@ without the original crash dump, live kernel, or even root access -- making
 it easy to share debugging context with colleagues or revisit a session
 offline.
 
-.. contents:: In this tutorial
-   :local:
-   :depth: 2
-
-
 How it works
 ------------
 

--- a/docs/tutorials/stacks.rst
+++ b/docs/tutorials/stacks.rst
@@ -6,11 +6,6 @@ commands when debugging Linux kernels.  It prints aggregated stack traces for
 kernel threads, making it easy to spot patterns, find blocked threads, and
 diagnose hangs.
 
-.. contents:: In this tutorial
-   :local:
-   :depth: 2
-
-
 Basic usage
 -----------
 


### PR DESCRIPTION
The furo theme provides its own sidebar navigation, so the ``.. contents::`` RST directive is redundant and renders an error banner on every page that uses it.