### PR TITLE
fix: resolve nightly mypy errors

### DIFF
--- a/sdb/commands/linux/internal/slub_helpers.py
+++ b/sdb/commands/linux/internal/slub_helpers.py
@@ -114,7 +114,7 @@ def entries_per_slab(cache: drgn.Object) -> int:
     Uses drgn's slab_cache_objects_per_slab() helper.
     """
     assert sdb.type_canonical_name(cache.type_) == 'struct kmem_cache *'
-    return slab_cache_objects_per_slab(cache)
+    return int(slab_cache_objects_per_slab(cache))
 
 
 def entry_size(cache: drgn.Object) -> int:

--- a/sdb/session.py
+++ b/sdb/session.py
@@ -28,7 +28,7 @@ ELF note sections.
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple
 
 from kdumpling import CompressionType, KdumpBuilder, OutputFormat
 
@@ -489,14 +489,15 @@ def extract_sdb_notes(vmcore_path: str) -> Optional[Dict[str, Any]]:
     """
     try:
         from elftools.elf.elffile import ELFFile
+        from elftools.elf.segments import NoteSegment
 
         with open(vmcore_path, 'rb') as f:
-            elf = ELFFile(f)  # type: ignore[no-untyped-call]
-            for segment in elf.iter_segments():  # type: ignore[no-untyped-call]
+            elf = ELFFile(f)
+            for segment in elf.iter_segments():
                 if segment['p_type'] == 'PT_NOTE':
-                    for note in segment.iter_notes():
-                        if note['n_name'] == 'SDB' and note[
-                                'n_type'] == SDB_NOTE_SESSION:
+                    for note in cast(NoteSegment, segment).iter_notes():
+                        note_type = cast(int, note['n_type'])
+                        if note['n_name'] == 'SDB' and note_type == SDB_NOTE_SESSION:
                             data = note['n_desc']
                             if isinstance(data, bytes):
                                 result: Dict[str, Any] = json.loads(


### PR DESCRIPTION
## Summary
- Update SDB ELF note extraction typing for pyelftools 0.33 so strict mypy accepts PT_NOTE iteration and custom SDB note types.
- Convert the drgn slab helper result to `int` to satisfy strict return typing under current mypy.

## Test plan
- `PYTHONPATH=.tmp-mypy-deps python3 -m mypy --strict --show-error-codes -p sdb`
- `PYTHONPATH=.tmp-check-deps python3 -m yapf --diff --style google --recursive sdb`
- `PYTHONPATH=.tmp-check-deps python3 -m ruff check sdb tests`

Notes: `python3 -m pytest -v tests/unit/test_session.py` could not run locally because this macOS Python environment is missing `drgn`.